### PR TITLE
Remove check for serviceaccount and namespace being *

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -125,7 +125,7 @@ func (b *kubeAuthBackend) pathLogin() framework.OperationFunc {
 					"service_account_name":        serviceAccount.name(),
 					"service_account_namespace":   serviceAccount.namespace(),
 					"service_account_secret_name": serviceAccount.SecretName,
-					"role": roleName,
+					"role":                        roleName,
 				},
 				DisplayName: fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name()),
 				LeaseOptions: logical.LeaseOptions{

--- a/path_login.go
+++ b/path_login.go
@@ -125,7 +125,7 @@ func (b *kubeAuthBackend) pathLogin() framework.OperationFunc {
 					"service_account_name":        serviceAccount.name(),
 					"service_account_namespace":   serviceAccount.namespace(),
 					"service_account_secret_name": serviceAccount.SecretName,
-					"role":                        roleName,
+					"role": roleName,
 				},
 				DisplayName: fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name()),
 				LeaseOptions: logical.LeaseOptions{

--- a/path_role.go
+++ b/path_role.go
@@ -35,12 +35,12 @@ func pathsRole(b *kubeAuthBackend) []*framework.Path {
 				"bound_service_account_names": &framework.FieldSchema{
 					Type: framework.TypeCommaStringSlice,
 					Description: `List of service account names able to access this role. If set to "*" all names
-are allowed, both this and bound_service_account_namespaces can not be "*"`,
+are allowed`,
 				},
 				"bound_service_account_namespaces": &framework.FieldSchema{
 					Type: framework.TypeCommaStringSlice,
 					Description: `List of namespaces allowed to access this role. If set to "*" all namespaces
-are allowed, both this and bound_service_account_names can not be set to "*"`,
+are allowed`,
 				},
 				"policies": &framework.FieldSchema{
 					Type:        framework.TypeCommaStringSlice,
@@ -277,11 +277,6 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate() framework.OperationFunc {
 		// Verify * was not set with other data
 		if len(role.ServiceAccountNamespaces) > 1 && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
 			return logical.ErrorResponse("can not mix \"*\" with values"), nil
-		}
-
-		// Verify that both names and namespaces are not set to "*"
-		if strutil.StrListContains(role.ServiceAccountNames, "*") && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
-			return logical.ErrorResponse("service_account_names and service_account_namespaces can not both be \"*\""), nil
 		}
 
 		// Parse bound CIDRs.

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -52,10 +52,10 @@ func TestPath_Create(t *testing.T) {
 		Period:                   3 * time.Second,
 		ServiceAccountNames:      []string{"name"},
 		ServiceAccountNamespaces: []string{"namespace"},
-		TTL:                      1 * time.Second,
-		MaxTTL:                   5 * time.Second,
-		NumUses:                  12,
-		BoundCIDRs:               []*sockaddr.SockAddrMarshaler{},
+		TTL:        1 * time.Second,
+		MaxTTL:     5 * time.Second,
+		NumUses:    12,
+		BoundCIDRs: []*sockaddr.SockAddrMarshaler{},
 	}
 
 	req := &logical.Request{

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -52,10 +52,10 @@ func TestPath_Create(t *testing.T) {
 		Period:                   3 * time.Second,
 		ServiceAccountNames:      []string{"name"},
 		ServiceAccountNamespaces: []string{"namespace"},
-		TTL:        1 * time.Second,
-		MaxTTL:     5 * time.Second,
-		NumUses:    12,
-		BoundCIDRs: []*sockaddr.SockAddrMarshaler{},
+		TTL:                      1 * time.Second,
+		MaxTTL:                   5 * time.Second,
+		NumUses:                  12,
+		BoundCIDRs:               []*sockaddr.SockAddrMarshaler{},
 	}
 
 	req := &logical.Request{

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -119,28 +119,6 @@ func TestPath_Create(t *testing.T) {
 		t.Fatalf("unexpected err: %v", resp)
 	}
 
-	// Test both "*"
-	data = map[string]interface{}{
-		"bound_service_account_names":      "*",
-		"bound_service_account_namespaces": "*",
-		"policies":                         "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "service_account_names and service_account_namespaces can not both be \"*\"" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
 	// Test mixed "*" and values
 	data = map[string]interface{}{
 		"bound_service_account_names":      "*, test",


### PR DESCRIPTION
Since #48 (#53) we're able to sensibly allow all serviceaccounts in all namespaces to authenticate to Vault, for example mapping them to a templated policy.
Since #58 we're able to get around the check by doing this: 
````
vault write auth/kubernetes/role/myrole \
bound_service_account_names=a*,b*,c*,d*,e*,f*,h*,i*,j*,k*,l*,m*,n*,o*,p*,q*,r*,s*,t*,u*,v*,w*,x*,y*,z*,1*,2*,3*,4*,5*,6*,7*,8*,9*,0* \ 
bound_service_account_namespaces=* policies=my_templated_policy
````
This PR is to remove the now unnecessary check for bound_service_account_name and bound_service_account_namespace being *