### PR TITLE
add display attributes necessary to create kubernetes roles in the ui

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -23,6 +23,10 @@ func pathsRole(b *kubeAuthBackend) []*framework.Path {
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role-list"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role-list"][1]),
+			DisplayAttrs: &framework.DisplayAttributes{
+				Navigation: true,
+				ItemType:   "Role",
+			},
 		},
 		&framework.Path{
 			Pattern: "role/" + framework.GenericNameRegex("name"),
@@ -85,6 +89,10 @@ are allowed, both this and bound_service_account_names can not be set to "*"`,
 			},
 			HelpSynopsis:    strings.TrimSpace(roleHelp["role"][0]),
 			HelpDescription: strings.TrimSpace(roleHelp["role"][1]),
+			DisplayAttrs: &framework.DisplayAttributes{
+				ItemType: "Role",
+				Action:   "Create",
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR sets the display attributes so we can use OpenApi to generate the CRUD views for kubernetes roles in the UI.

Don't merge this until https://github.com/hashicorp/vault/pull/7513 is merged!