### PR TITLE
send audience to tokenreview api

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -351,7 +351,7 @@ type projectedServiceAccountPod struct {
 // lookup calls the TokenReview API in kubernetes to verify the token and secret
 // still exist.
 func (s *serviceAccount) lookup(jwtStr string, tr tokenReviewer) error {
-	r, err := tr.Review(jwtStr)
+	r, err := tr.Review(jwtStr, s.Audience)
 	if err != nil {
 		return err
 	}

--- a/token_review.go
+++ b/token_review.go
@@ -28,7 +28,7 @@ type tokenReviewResult struct {
 
 // This exists so we can use a mock TokenReview when running tests
 type tokenReviewer interface {
-	Review(string) (*tokenReviewResult, error)
+	Review(string, []string) (*tokenReviewResult, error)
 }
 
 type tokenReviewFactory func(*kubeConfig) tokenReviewer
@@ -44,7 +44,7 @@ func tokenReviewAPIFactory(config *kubeConfig) tokenReviewer {
 	}
 }
 
-func (t *tokenReviewAPI) Review(jwt string) (*tokenReviewResult, error) {
+func (t *tokenReviewAPI) Review(jwt string, aud []string) (*tokenReviewResult, error) {
 
 	client := cleanhttp.DefaultClient()
 
@@ -64,7 +64,8 @@ func (t *tokenReviewAPI) Review(jwt string) (*tokenReviewResult, error) {
 	// Create the TokenReview Object and marshal it into json
 	trReq := &authv1.TokenReview{
 		Spec: authv1.TokenReviewSpec{
-			Token: jwt,
+			Token:     jwt,
+			Audiences: aud,
 		},
 	}
 	trJSON, err := json.Marshal(trReq)
@@ -187,7 +188,7 @@ func mockTokenReviewFactory(name, namespace, UID string) tokenReviewFactory {
 	}
 }
 
-func (t *mockTokenReview) Review(jwt string) (*tokenReviewResult, error) {
+func (t *mockTokenReview) Review(jwt string, aud []string) (*tokenReviewResult, error) {
 	return &tokenReviewResult{
 		Name:      t.saName,
 		Namespace: t.saNamespace,


### PR DESCRIPTION
This PR addresses #73.

I've tested this with EKS 1.14.
This setup requires a `token_reviewer_jwt` with `system:auth-delegator` permissions. Also EKS projected tokens are not issued from kubernetes, but from OIDC (https://oidc.eks.us-east-1.amazonaws.com/id/<your-cluster-random-id>), so this requires the configuration of `issuer` as well.

Here's my config:

```
vault write auth/kubernetes/config \
kubernetes_host=https://CF07473106A573AC4F2567E17CF8B150.gr7.us-east-1.eks.amazonaws.com \
kubernetes_ca_cert=@ca.crt \
issuer="https://oidc.eks.us-east-1.amazonaws.com/id/CF07473106A573AC4F2567E17CF8B150" \
token_reviewer_jwt="<MY_JWT_REVIEWER_TOKEN>"
```

Old authentication w/o audience also works, just make sure your role isn't provisioned with it and general config issuer is the default one (e.g. no `issuer` setting).