### PR TITLE
Allow both service account names and namespaces to be splat

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -105,7 +105,8 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 	// look up the JWT token in the kubernetes API
 	err = serviceAccount.lookup(jwtStr, b.reviewFactory(config))
 	if err != nil {
-		return nil, err
+		b.Logger().Error(`login unauthorized due to: ` + err.Error())
+		return nil, logical.ErrPermissionDenied
 	}
 
 	auth := &logical.Auth{

--- a/path_role.go
+++ b/path_role.go
@@ -16,7 +16,7 @@ import (
 // pathsRole returns the path configurations for the CRUD operations on roles
 func pathsRole(b *kubeAuthBackend) []*framework.Path {
 	p := []*framework.Path{
-		&framework.Path{
+		{
 			Pattern: "role/?",
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.ListOperation: b.pathRoleList,
@@ -295,11 +295,6 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	// Verify * was not set with other data
 	if len(role.ServiceAccountNamespaces) > 1 && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
 		return logical.ErrorResponse("can not mix \"*\" with values"), nil
-	}
-
-	// Verify that both names and namespaces are not set to "*"
-	if strutil.StrListContains(role.ServiceAccountNames, "*") && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
-		return logical.ErrorResponse("service_account_names and service_account_namespaces can not both be \"*\""), nil
 	}
 
 	// optional audience field

--- a/path_role.go
+++ b/path_role.go
@@ -38,12 +38,12 @@ func pathsRole(b *kubeAuthBackend) []*framework.Path {
 				"bound_service_account_names": {
 					Type: framework.TypeCommaStringSlice,
 					Description: `List of service account names able to access this role. If set to "*" all names
-are allowed, both this and bound_service_account_namespaces can not be "*"`,
+are allowed.`,
 				},
 				"bound_service_account_namespaces": {
 					Type: framework.TypeCommaStringSlice,
 					Description: `List of namespaces allowed to access this role. If set to "*" all namespaces
-are allowed, both this and bound_service_account_names can not be set to "*"`,
+are allowed.`,
 				},
 				"audience": {
 					Type:        framework.TypeString,

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -127,28 +127,6 @@ func TestPath_Create(t *testing.T) {
 		t.Fatalf("unexpected err: %v", resp)
 	}
 
-	// Test both "*"
-	data = map[string]interface{}{
-		"bound_service_account_names":      "*",
-		"bound_service_account_namespaces": "*",
-		"policies":                         "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "service_account_names and service_account_namespaces can not both be \"*\"" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
 	// Test mixed "*" and values
 	data = map[string]interface{}{
 		"bound_service_account_names":      "*, test",


### PR DESCRIPTION
Relates to #47 

This PR is very similar to #66 but adds positive and negative login tests of the newly allowed configuration to verify that it's still not possible to log in with bad data.