### PR TITLE
Adds optional validate_iss_claim config param to allow skip iss validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/hashicorp/go-hclog v0.12.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-sockaddr v1.0.2
+	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
 	k8s.io/api v0.0.0-20190409092523-d687e77c8ae9

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
 	k8s.io/api v0.0.0-20190409092523-d687e77c8ae9

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr6
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang/dep v0.5.4 h1:WfV5qbGwsBNUDhk+pfI6emWm7SdDFsnSWkqCMNG3BRs=
+github.com/golang/dep v0.5.4/go.mod h1:6RZ2Wai7dSWk7qL55sDYk+8UPFqcW7all2KDBraPPFA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -72,8 +74,11 @@ github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjG
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
+github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -110,6 +115,10 @@ github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
+github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr6
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/golang/dep v0.5.4 h1:WfV5qbGwsBNUDhk+pfI6emWm7SdDFsnSWkqCMNG3BRs=
-github.com/golang/dep v0.5.4/go.mod h1:6RZ2Wai7dSWk7qL55sDYk+8UPFqcW7all2KDBraPPFA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -74,7 +72,6 @@ github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjG
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
@@ -115,10 +112,6 @@ github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
-github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
-github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
-github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
-github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/path_config.go
+++ b/path_config.go
@@ -59,7 +59,7 @@ extracted. Not every installation of Kuberentes exposes these keys.`,
 			},
 			"disable_iss_validation": {
 				Type:        framework.TypeBool,
-				Description: "Optional JWT issuer validation. Allows to skip ISS validation.",
+				Description: "Disable JWT issuer validation. Allows to skip ISS validation.",
 				Default:     false,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Disable JWT Issuer Validation",

--- a/path_config.go
+++ b/path_config.go
@@ -168,7 +168,7 @@ type kubeConfig struct {
 	TokenReviewerJWT string `json:"token_reviewer_jwt"`
 	// Issuer is the claim that specifies who issued the token
 	Issuer string `json:"issuer"`
-	// ValidateISSClaim is an option to skip ISS validation
+	// ValidateISSClaim is optional parameter to allow to skip ISS validation
 	ValidateISSClaim bool `json:"validate_iss_claim"`
 }
 

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -12,11 +12,11 @@ func TestConfig_Read(t *testing.T) {
 	b, storage := getBackend(t)
 
 	data := map[string]interface{}{
-		"pem_keys":           []string{testRSACert, testECCert},
-		"kubernetes_host":    "host",
-		"kubernetes_ca_cert": testCACert,
-		"issuer":             "",
-		"validate_iss_claim": true,
+		"pem_keys":               []string{testRSACert, testECCert},
+		"kubernetes_host":        "host",
+		"kubernetes_ca_cert":     testCACert,
+		"issuer":                 "",
+		"disable_iss_validation": false,
 	}
 
 	req := &logical.Request{
@@ -136,11 +136,11 @@ func TestConfig(t *testing.T) {
 	}
 
 	expected := &kubeConfig{
-		PublicKeys:       []interface{}{},
-		PEMKeys:          []string{},
-		Host:             "host",
-		CACert:           testCACert,
-		ValidateISSClaim: true,
+		PublicKeys:           []interface{}{},
+		PEMKeys:              []string{},
+		Host:                 "host",
+		CACert:               testCACert,
+		DisableISSValidation: false,
 	}
 
 	conf, err := b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -177,12 +177,12 @@ func TestConfig(t *testing.T) {
 	}
 
 	expected = &kubeConfig{
-		PublicKeys:       []interface{}{},
-		PEMKeys:          []string{},
-		Host:             "host",
-		CACert:           testCACert,
-		TokenReviewerJWT: jwtData,
-		ValidateISSClaim: true,
+		PublicKeys:           []interface{}{},
+		PEMKeys:              []string{},
+		Host:                 "host",
+		CACert:               testCACert,
+		TokenReviewerJWT:     jwtData,
+		DisableISSValidation: false,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -219,11 +219,11 @@ func TestConfig(t *testing.T) {
 	}
 
 	expected = &kubeConfig{
-		PublicKeys:       []interface{}{cert},
-		PEMKeys:          []string{testRSACert},
-		Host:             "host",
-		CACert:           testCACert,
-		ValidateISSClaim: true,
+		PublicKeys:           []interface{}{cert},
+		PEMKeys:              []string{testRSACert},
+		Host:                 "host",
+		CACert:               testCACert,
+		DisableISSValidation: false,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -265,11 +265,11 @@ func TestConfig(t *testing.T) {
 	}
 
 	expected = &kubeConfig{
-		PublicKeys:       []interface{}{cert, cert2},
-		PEMKeys:          []string{testRSACert, testECCert},
-		Host:             "host",
-		CACert:           testCACert,
-		ValidateISSClaim: true,
+		PublicKeys:           []interface{}{cert, cert2},
+		PEMKeys:              []string{testRSACert, testECCert},
+		Host:                 "host",
+		CACert:               testCACert,
+		DisableISSValidation: false,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -16,6 +16,7 @@ func TestConfig_Read(t *testing.T) {
 		"kubernetes_host":    "host",
 		"kubernetes_ca_cert": testCACert,
 		"issuer":             "",
+		"validate_iss_claim": true,
 	}
 
 	req := &logical.Request{
@@ -135,10 +136,11 @@ func TestConfig(t *testing.T) {
 	}
 
 	expected := &kubeConfig{
-		PublicKeys: []interface{}{},
-		PEMKeys:    []string{},
-		Host:       "host",
-		CACert:     testCACert,
+		PublicKeys:       []interface{}{},
+		PEMKeys:          []string{},
+		Host:             "host",
+		CACert:           testCACert,
+		ValidateISSClaim: true,
 	}
 
 	conf, err := b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -180,6 +182,7 @@ func TestConfig(t *testing.T) {
 		Host:             "host",
 		CACert:           testCACert,
 		TokenReviewerJWT: jwtData,
+		ValidateISSClaim: true,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -216,10 +219,11 @@ func TestConfig(t *testing.T) {
 	}
 
 	expected = &kubeConfig{
-		PublicKeys: []interface{}{cert},
-		PEMKeys:    []string{testRSACert},
-		Host:       "host",
-		CACert:     testCACert,
+		PublicKeys:       []interface{}{cert},
+		PEMKeys:          []string{testRSACert},
+		Host:             "host",
+		CACert:           testCACert,
+		ValidateISSClaim: true,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -261,10 +265,11 @@ func TestConfig(t *testing.T) {
 	}
 
 	expected = &kubeConfig{
-		PublicKeys: []interface{}{cert, cert2},
-		PEMKeys:    []string{testRSACert, testECCert},
-		Host:       "host",
-		CACert:     testCACert,
+		PublicKeys:       []interface{}{cert, cert2},
+		PEMKeys:          []string{testRSACert, testECCert},
+		Host:             "host",
+		CACert:           testCACert,
+		ValidateISSClaim: true,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)

--- a/path_login.go
+++ b/path_login.go
@@ -203,11 +203,14 @@ func (b *kubeAuthBackend) parseAndValidateJWT(jwtStr string, role *roleStorageEn
 		},
 	}
 
-	// set the expected issuer to the default kubernetes issuer if the config doesn't specify it
-	if config.Issuer != "" {
-		validator.SetIssuer(config.Issuer)
-	} else {
-		validator.SetIssuer(defaultJWTIssuer)
+	// perform ISS Claim validation if configured
+	if config.ValidateISSClaim {
+		// set the expected issuer to the default kubernetes issuer if the config doesn't specify it
+		if config.Issuer != "" {
+			validator.SetIssuer(config.Issuer)
+		} else {
+			validator.SetIssuer(defaultJWTIssuer)
+		}
 	}
 
 	// validate the audience if the role expects it

--- a/path_login.go
+++ b/path_login.go
@@ -204,7 +204,7 @@ func (b *kubeAuthBackend) parseAndValidateJWT(jwtStr string, role *roleStorageEn
 	}
 
 	// perform ISS Claim validation if configured
-	if config.ValidateISSClaim {
+	if !config.DisableISSValidation {
 		// set the expected issuer to the default kubernetes issuer if the config doesn't specify it
 		if config.Issuer != "" {
 			validator.SetIssuer(config.Issuer)


### PR DESCRIPTION
Issuer validation should be optional and there should be a way to disable iss validation because currently if issuer will be changed all clients will not be able to log-in.

As per JWT spec issuer can be optional and it is optional in this plugin 
```
Description: "Optional JWT issuer. If no issuer is specified, then this plugin will use kubernetes.io/serviceaccount as the default issuer.",
```
However, with non-default issuer auth will fail due to validation as it will try to validate it against default `kubernetes.io/serviceaccount`.

Another way to avoid such issues is to stop trying to validate against default issuer `kubernetes.io/serviceaccount` and do validation only if issuer is explicitly set in the configuration 
but I am not sure about the backward compatibility of that approach.

fixes: https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/90


If that looks good I will open PRs to update Vault docs and terraform Vault provider to support this new param.




tests are passing:

```

$ make testacc

==> Checking that code complies with gofmt requirements...
go generate 
VAULT_ACC=1 go test -tags='vault-plugin-auth-kubernetes' $(go list ./... | grep -v /vendor/) -v  -timeout 45m
=== RUN   TestConfig_Read
--- PASS: TestConfig_Read (0.00s)
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
=== RUN   TestLogin
--- PASS: TestLogin (0.00s)
=== RUN   TestLogin_ECDSA_PEM
--- PASS: TestLogin_ECDSA_PEM (0.01s)
=== RUN   TestLogin_NoPEMs
--- PASS: TestLogin_NoPEMs (0.00s)
=== RUN   TestLoginSvcAcctAndNamespaceSplats
2020-06-04T12:12:36.007+0300 [ERROR] login unauthorized due to: JWT names did not match
--- PASS: TestLoginSvcAcctAndNamespaceSplats (0.00s)
=== RUN   TestAliasLookAhead
--- PASS: TestAliasLookAhead (0.00s)
=== RUN   TestLoginIssValidation
--- PASS: TestLoginIssValidation (0.00s)
=== RUN   TestLoginProjectedToken
=== RUN   TestLoginProjectedToken/normal
=== RUN   TestLoginProjectedToken/fail
=== RUN   TestLoginProjectedToken/projected-token
=== RUN   TestLoginProjectedToken/projected-token-expired
=== RUN   TestLoginProjectedToken/projected-token-invalid-role
--- PASS: TestLoginProjectedToken (0.00s)
    --- PASS: TestLoginProjectedToken/normal (0.00s)
    --- PASS: TestLoginProjectedToken/fail (0.00s)
    --- PASS: TestLoginProjectedToken/projected-token (0.00s)
    --- PASS: TestLoginProjectedToken/projected-token-expired (0.00s)
    --- PASS: TestLoginProjectedToken/projected-token-invalid-role (0.00s)
=== RUN   TestPath_Create
--- PASS: TestPath_Create (0.00s)
=== RUN   TestPath_Read
--- PASS: TestPath_Read (0.00s)
=== RUN   TestPath_Delete
--- PASS: TestPath_Delete (0.00s)
PASS
ok      github.com/hashicorp/vault-plugin-auth-kubernetes       0.843s
?       github.com/hashicorp/vault-plugin-auth-kubernetes/cmd/vault-plugin-auth-kubernetes      [no test files]
```