### PR TITLE
fix: use local token for TokenReviewer JWT only when using token for CA crt (#93)

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -115,17 +115,16 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 	caCert := data.Get("kubernetes_ca_cert").(string)
 	issuer := data.Get("issuer").(string)
 	disableIssValidation := data.Get("disable_iss_validation").(bool)
+	tokenReviewer := data.Get("token_reviewer_jwt").(string)
 	if len(pemList) == 0 && len(caCert) == 0 {
 		if len(localCACert) > 0 {
 			caCert = string(localCACert)
+			if len(tokenReviewer) == 0 && len(localTokenReviewer) > 0 {
+				tokenReviewer = string(localTokenReviewer)
+			}
 		} else {
 			return logical.ErrorResponse("one of pem_keys or kubernetes_ca_cert must be set"), nil
 		}
-	}
-
-	tokenReviewer := data.Get("token_reviewer_jwt").(string)
-	if len(tokenReviewer) == 0 && len(localTokenReviewer) > 0 {
-		tokenReviewer = string(localTokenReviewer)
 	}
 
 	if len(tokenReviewer) > 0 {


### PR DESCRIPTION
PR #83  added ability to read ca.crt and TokenReviewer JWT from the default service account under which Vault is running.

This ended up causing a breakage when trying to authenticate against external clusters in which no TokenReview JWT is specified in the configuration.

The changes in this PR make the assumption that the default service account TokenReviewer JWT should only be used if no CA certificate (or pem keys) are supplied and therefore they are read from the default service account. 