### PR TITLE
Adds new config option `disable_local_ca_jwt`

### DIFF
--- a/path_config_test.go
+++ b/path_config_test.go
@@ -2,6 +2,8 @@ package kubeauth
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -17,6 +19,7 @@ func TestConfig_Read(t *testing.T) {
 		"kubernetes_ca_cert":     testCACert,
 		"issuer":                 "",
 		"disable_iss_validation": false,
+		"disable_local_ca_jwt":   false,
 	}
 
 	req := &logical.Request{
@@ -183,6 +186,7 @@ func TestConfig(t *testing.T) {
 		CACert:               testCACert,
 		TokenReviewerJWT:     jwtData,
 		DisableISSValidation: false,
+		DisableLocalCAJwt:    false,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -224,6 +228,7 @@ func TestConfig(t *testing.T) {
 		Host:                 "host",
 		CACert:               testCACert,
 		DisableISSValidation: false,
+		DisableLocalCAJwt:    false,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -270,6 +275,7 @@ func TestConfig(t *testing.T) {
 		Host:                 "host",
 		CACert:               testCACert,
 		DisableISSValidation: false,
+		DisableLocalCAJwt:    false,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -311,6 +317,7 @@ func TestConfig(t *testing.T) {
 		Host:                 "host",
 		CACert:               testCACert,
 		DisableISSValidation: true,
+		DisableLocalCAJwt:    false,
 	}
 
 	conf, err = b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -322,6 +329,221 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("expected did not match actual: expected %#v\n got %#v\n", expected, conf)
 	}
 }
+
+func TestConfig_LocalCaJWT(t *testing.T) {
+	b, storage := getBackend(t)
+
+	t.Run("no CA or JWT, default to local", func(t *testing.T) {
+		data := map[string]interface{}{
+			"kubernetes_host": "host",
+		}
+
+		// write "local" CA and JWT, and override local path vars
+		caFile := writeToTempFile(t, testLocalCACert)
+		localCACertPath = caFile
+		defer os.Remove(caFile)
+		jwtFile := writeToTempFile(t, testLocalJWT)
+		localJWTPath = jwtFile
+		defer os.Remove(jwtFile)
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, resp)
+		}
+
+		expected := &kubeConfig{
+			PublicKeys:           []interface{}{},
+			PEMKeys:              []string{},
+			Host:                 "host",
+			CACert:               testLocalCACert,
+			TokenReviewerJWT:     testLocalJWT,
+			DisableISSValidation: false,
+			DisableLocalCAJwt:    false,
+		}
+
+		conf, err := b.(*kubeAuthBackend).config(context.Background(), storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(expected, conf) {
+			t.Fatalf("expected did not match actual: expected %#v\n got %#v\n", expected, conf)
+		}
+
+	})
+
+	t.Run("CA set, default to local JWT", func(t *testing.T) {
+		data := map[string]interface{}{
+			"kubernetes_host":    "host",
+			"kubernetes_ca_cert": testCACert,
+		}
+
+		// write "local" JWT, and override local path var
+		jwtFile := writeToTempFile(t, testLocalJWT)
+		localJWTPath = jwtFile
+		defer os.Remove(jwtFile)
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, resp)
+		}
+
+		expected := &kubeConfig{
+			PublicKeys:           []interface{}{},
+			PEMKeys:              []string{},
+			Host:                 "host",
+			CACert:               testCACert,
+			TokenReviewerJWT:     testLocalJWT,
+			DisableISSValidation: false,
+			DisableLocalCAJwt:    false,
+		}
+
+		conf, err := b.(*kubeAuthBackend).config(context.Background(), storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(expected, conf) {
+			t.Fatalf("expected did not match actual: expected %#v\n got %#v\n", expected, conf)
+		}
+
+	})
+
+	t.Run("JWT set, default to local CA", func(t *testing.T) {
+		data := map[string]interface{}{
+			"kubernetes_host":    "host",
+			"token_reviewer_jwt": jwtData,
+		}
+
+		// write "local" CA, and override local path var
+		caFile := writeToTempFile(t, testLocalCACert)
+		localCACertPath = caFile
+		defer os.Remove(caFile)
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, resp)
+		}
+
+		expected := &kubeConfig{
+			PublicKeys:           []interface{}{},
+			PEMKeys:              []string{},
+			Host:                 "host",
+			CACert:               testLocalCACert,
+			TokenReviewerJWT:     jwtData,
+			DisableISSValidation: false,
+			DisableLocalCAJwt:    false,
+		}
+
+		conf, err := b.(*kubeAuthBackend).config(context.Background(), storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(expected, conf) {
+			t.Fatalf("expected did not match actual: expected %#v\n got %#v\n", expected, conf)
+		}
+
+	})
+
+	t.Run("CA and disable local default", func(t *testing.T) {
+		data := map[string]interface{}{
+			"kubernetes_host":      "host",
+			"kubernetes_ca_cert":   testCACert,
+			"disable_local_ca_jwt": true,
+		}
+
+		req := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      configPath,
+			Storage:   storage,
+			Data:      data,
+		}
+
+		resp, err := b.HandleRequest(context.Background(), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, resp)
+		}
+
+		expected := &kubeConfig{
+			PublicKeys:           []interface{}{},
+			PEMKeys:              []string{},
+			Host:                 "host",
+			CACert:               testCACert,
+			TokenReviewerJWT:     "",
+			DisableISSValidation: false,
+			DisableLocalCAJwt:    true,
+		}
+
+		conf, err := b.(*kubeAuthBackend).config(context.Background(), storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(expected, conf) {
+			t.Fatalf("expected did not match actual: expected %#v\n got %#v\n", expected, conf)
+		}
+
+	})
+}
+
+func writeToTempFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatalf("Failure to create test file: %s", err)
+	}
+	_, err = f.WriteString(contents)
+	if err != nil {
+		t.Fatalf("Failure to write test file: %s", err)
+	}
+	return f.Name()
+}
+
+var testLocalCACert string = `-----BEGIN CERTIFICATE-----
+MIIDVDCCAjwCCQDFiyFY1M6afTANBgkqhkiG9w0BAQsFADBsMQswCQYDVQQGEwJV
+UzETMBEGA1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEgMB4GA1UE
+CgwXVmF1bHQgVGVzdGluZyBBdXRob3JpdHkxFDASBgNVBAMMC2V4YW1wbGUubmV0
+MB4XDTIwMDkxODAxMjkxM1oXDTQ1MDkxODAxMjkxM1owbDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIDAeBgNVBAoM
+F1ZhdWx0IFRlc3RpbmcgQXV0aG9yaXR5MRQwEgYDVQQDDAtleGFtcGxlLm5ldDCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALCA9oKv+ESRHX2e/iq1PlGr
+zD23/MBS0V+fWQDY0hyEqY98CGwRtF6pEcLEYsreArj5/zznsIevLkNOD+beg43y
+WpEJlCPgDhGXI/Oima6ooHVEIMaIKLjK7GrSzAb3rNRGACwrR/u/IKaFl+XJG0qx
+g8mOZ3fByaAlIk+shVLUcIedNN1tNR+6/4ZpHg7PDjrZXP4XKrmKPTh4yqfu+BtZ
+9IY2oyregqEsGW1/3h1NM+LHGVakTV2d/mwMYHhwoq9Y8BD+PemT5z8TmhH/cIk5
+P8Q8ud5/q6YTIJg9TELKebLAeNtRNnNoHeUoRTjiW1MBwNHtgyTTY+H3W/9Dne0C
+AwEAATANBgkqhkiG9w0BAQsFAAOCAQEAXmygFkGIBnXxKlsTDiV8RW2iHLgFdZFJ
+hcU8UpxZhhaL5JbQl6byfbHjrX31q7ii8uC8FcbW0AEdnEQAb9Ui6a+if7HwXNmI
+DTlYl+lMlk9RtWvExw6AEEbg5nCpGaKexm7wJgzYGP9by9pQ7wX/CS7ofCzCK+Al
+uSIqjPkMC201ZXH39n1lxxq6BacdYjv8wo4mMzi8iTSQGVWPdjHZVYOClFgN6hoj
+8SkrrSe888a0H+i7EknRxC4sLRaMUK/FAvwtXaSZi2djruAtQzQGQ56m1phC2C/k
+k9aL00AQ9Y4KTfiJD7LK8YIZDnFKLOCJhYgKCLCOVwOHb7836SNCxA==
+-----END CERTIFICATE-----`
+
+var testLocalJWT string = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlZhdWx0IFRlc3QiLCJpYXQiOjExMjM1OH0.GOC8w-MyhorgojB20SPNyH_ECsBjYJH89hjntOxSywA`
 
 var testRSACert string = `-----BEGIN CERTIFICATE-----
 MIIDcjCCAlqgAwIBAgIBAjANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwptaW5p


### PR DESCRIPTION
# Overview
Adds an option to disable defaulting to the local CA cert and service account JWT
when running in a Kubernetes pod.

# Design of Change
Adds a new config option `disable_local_ca_jwt` which defaults to `false`. So by default, the current behavior is preserved: if either `kubernetes_ca_cert` or `token_reviewer_jwt` isn't specified, the local version in the pod will be used. Setting `disable_local_ca_jwt=true` disables using the local versions.

# Related Issues/Pull Requests
- [Issue #93](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/93)
- [PR #94](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/94)

# Contributor Checklist
- [x] [My Docs PR Link](https://github.com/hashicorp/vault/pull/9992)
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
<details>
  <summary>testacc output, Click to expand!</summary>

```
❯ make testacc
==> Checking that code complies with gofmt requirements...
go generate 
VAULT_ACC=1 go test -tags='vault-plugin-auth-kubernetes' $(go list ./... | grep -v /vendor/) -v  -timeout 45m
=== RUN   TestConfig_Read
--- PASS: TestConfig_Read (0.00s)
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
=== RUN   TestConfig_LocalCaJWT
=== RUN   TestConfig_LocalCaJWT/no_CA_or_JWT,_default_to_local
=== RUN   TestConfig_LocalCaJWT/CA_set,_default_to_local_JWT
=== RUN   TestConfig_LocalCaJWT/JWT_set,_default_to_local_CA
=== RUN   TestConfig_LocalCaJWT/CA_and_disable_local_default
--- PASS: TestConfig_LocalCaJWT (0.00s)
    --- PASS: TestConfig_LocalCaJWT/no_CA_or_JWT,_default_to_local (0.00s)
    --- PASS: TestConfig_LocalCaJWT/CA_set,_default_to_local_JWT (0.00s)
    --- PASS: TestConfig_LocalCaJWT/JWT_set,_default_to_local_CA (0.00s)
    --- PASS: TestConfig_LocalCaJWT/CA_and_disable_local_default (0.00s)
=== RUN   TestLogin
--- PASS: TestLogin (0.00s)
=== RUN   TestLogin_ECDSA_PEM
--- PASS: TestLogin_ECDSA_PEM (0.01s)
=== RUN   TestLogin_NoPEMs
--- PASS: TestLogin_NoPEMs (0.00s)
=== RUN   TestLoginSvcAcctAndNamespaceSplats
2020-09-18T13:42:49.955-0700 [ERROR] login unauthorized due to: JWT names did not match
--- PASS: TestLoginSvcAcctAndNamespaceSplats (0.00s)
=== RUN   TestAliasLookAhead
--- PASS: TestAliasLookAhead (0.00s)
=== RUN   TestLoginIssValidation
--- PASS: TestLoginIssValidation (0.00s)
=== RUN   TestLoginProjectedToken
=== RUN   TestLoginProjectedToken/normal
=== RUN   TestLoginProjectedToken/fail
=== RUN   TestLoginProjectedToken/projected-token
=== RUN   TestLoginProjectedToken/projected-token-expired
=== RUN   TestLoginProjectedToken/projected-token-invalid-role
--- PASS: TestLoginProjectedToken (0.00s)
    --- PASS: TestLoginProjectedToken/normal (0.00s)
    --- PASS: TestLoginProjectedToken/fail (0.00s)
    --- PASS: TestLoginProjectedToken/projected-token (0.00s)
    --- PASS: TestLoginProjectedToken/projected-token-expired (0.00s)
    --- PASS: TestLoginProjectedToken/projected-token-invalid-role (0.00s)
=== RUN   TestPath_Create
--- PASS: TestPath_Create (0.00s)
=== RUN   TestPath_Read
--- PASS: TestPath_Read (0.00s)
=== RUN   TestPath_Delete
--- PASS: TestPath_Delete (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-auth-kubernetes	0.342s
?   	github.com/hashicorp/vault-plugin-auth-kubernetes/cmd/vault-plugin-auth-kubernetes	[no test files]

```
</details>

- [x] Backwards compatible
