### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.12
     working_directory: /go/src/github.com/hashicorp/vault-plugin-auth-kubernetes
     steps:
       - checkout


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. We're updating CircleCI configs, docker compose, dockerfiles, relevant parts of Makefiles, and travis configs. Github actions are excluded, as Github is handling the issue on their end. LMK if you have any q's, otherwise feel free to approve and merge on your own! 