### PR TITLE
Updated jwt projected tokens

### DIFF
--- a/path_login_test.go
+++ b/path_login_test.go
@@ -24,7 +24,7 @@ var (
 	// Projected ServiceAccount tokens have name "default", and require a
 	// different mock token reviewer
 	testProjectedName        = "default"
-	testProjectedUID         = "b389b3b2-d302-11e8-b14c-080027e55ea8"
+	testProjectedUID         = "77c81ad7-1bea-4d94-9ca5-f5d7f3632331"
 	testProjectedMockFactory = mockTokenReviewFactory(testProjectedName, testNamespace, testProjectedUID)
 
 	testDefaultPEMs = []string{testECCert, testRSACert}
@@ -828,12 +828,23 @@ func TestLoginProjectedToken(t *testing.T) {
 			if err != nil && tc.e == nil {
 				t.Fatalf("unexpected err: (%s) resp:%#v\n", err, resp)
 			}
+			if err == nil && !resp.IsError() && tc.e != nil {
+				t.Fatalf("expected error but found none: (%s) resp: %#v\n", tc.e, resp)
+			}
 			if resp != nil && resp.IsError() {
 				if tc.e == nil {
 					t.Fatalf("unexpected err: (%s)\n", resp.Error())
 				}
 				if tc.e.Error() != resp.Error().Error() {
-					t.Fatalf("error mismatch, expected (%s) got (%s)", tc.e, resp.Error())
+					t.Fatalf("error mismatch in response, expected (%s) got (%s)", tc.e, resp.Error())
+				}
+			}
+			if resp == nil && err != nil {
+				if tc.e != nil && tc.e.Error() != err.Error() {
+					t.Fatalf("error mismatch, expected (%s) got (%s)", tc.e, err)
+				}
+				if tc.e == nil {
+					t.Fatalf("unexpected err: (%s)", err)
 				}
 			}
 		})
@@ -841,56 +852,56 @@ func TestLoginProjectedToken(t *testing.T) {
 }
 
 // jwtProjectedData is a Projected Service Account jwt with expiration set to
-// October 19, 2020
+// 05 Nov 2030 04:19:57 (UTC)
 //
 // {
-//   "aud": [
-//     "kubernetes.default.svc"
-//   ],
-//   "exp": 1603053563,
-//   "iat": 1539981563,
-//   "iss": "kubernetes/serviceaccount",
-//   "kubernetes.io": {
-//     "namespace": "default",
-//     "pod": {
-//       "name": "vault",
-//       "uid": "1006a06c-d3df-11e8-8fe2-080027e55ea8"
-//     },
-//     "serviceaccount": {
-//       "name": "default",
-//       "uid": "b389b3b2-d302-11e8-b14c-080027e55ea8"
-//     }
-//   },
-//   "nbf": 1539981563,
-//   "sub": "system:serviceaccount:default:default"
+// 	"aud": [
+// 	  "kubernetes.default.svc"
+// 	],
+// 	"exp": 1920082797,
+// 	"iat": 1604082797,
+// 	"iss": "kubernetes/serviceaccount",
+// 	"kubernetes.io": {
+// 	  "namespace": "default",
+// 	  "pod": {
+// 		"name": "vault",
+// 		"uid": "086c2f61-dea2-47bb-b5ca-63e63c5c9885"
+// 	  },
+// 	  "serviceaccount": {
+// 		"name": "default",
+// 		"uid": "77c81ad7-1bea-4d94-9ca5-f5d7f3632331"
+// 	  }
+// 	},
+// 	"nbf": 1604082797,
+// 	"sub": "system:serviceaccount:default:default"
 // }
-var jwtProjectedData = "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJhdWQiOlsia3ViZXJuZXRlcy5kZWZhdWx0LnN2YyJdLCJleHAiOjE2MDMwNTM1NjMsImlhdCI6MTUzOTk4MTU2MywiaXNzIjoia3ViZXJuZXRlcy9zZXJ2aWNlYWNjb3VudCIsImt1YmVybmV0ZXMuaW8iOnsibmFtZXNwYWNlIjoiZGVmYXVsdCIsInBvZCI6eyJuYW1lIjoidmF1bHQiLCJ1aWQiOiIxMDA2YTA2Yy1kM2RmLTExZTgtOGZlMi0wODAwMjdlNTVlYTgifSwic2VydmljZWFjY291bnQiOnsibmFtZSI6ImRlZmF1bHQiLCJ1aWQiOiJiMzg5YjNiMi1kMzAyLTExZTgtYjE0Yy0wODAwMjdlNTVlYTgifX0sIm5iZiI6MTUzOTk4MTU2Mywic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6ZGVmYXVsdCJ9.byu3BpCbs0tzQvEBCRTayXF3-kV1Ey7YvStBcCwovfSl6evBze43FFaDps78HtdDAMszjE_yn55_1BMN87EzOZYsF3GBoPLWxkofxhPIy88wmPTpurBsSx-nCKdjf4ayXhTpqGG9gy0xlkUc_xL4pM3Q8XZiqYqwq_T0PHXOpSfdzVy1oabFSZXr5QTZ377v8bvrMgAVWJF_4vZsSMG3XVCK8KBWNRw4_wt6yOelVKE5OGLPJvNu1CFjEKh4HBFBcQnB_Sgpe1nPlnm5utp-1-OVfd7zopOGDAp_Pk_Apu8OPDdPSafn6HpzIeuhMtWXcv1K8ZhZYDLC1wLywZPNyw"
+var jwtProjectedData = "eyJhbGciOiJSUzI1NiIsImtpZCI6InBKY3hrSjRxME8xdE90MFozN1ZCNi14Nk13OHhGWlN4TTlyb1B0TVFxMEEifQ.eyJhdWQiOlsia3ViZXJuZXRlcy5kZWZhdWx0LnN2YyJdLCJleHAiOjE5MjAwODI3OTcsImlhdCI6MTYwNDA4Mjc5NywiaXNzIjoia3ViZXJuZXRlcy9zZXJ2aWNlYWNjb3VudCIsImt1YmVybmV0ZXMuaW8iOnsibmFtZXNwYWNlIjoiZGVmYXVsdCIsInBvZCI6eyJuYW1lIjoidmF1bHQiLCJ1aWQiOiIwODZjMmY2MS1kZWEyLTQ3YmItYjVjYS02M2U2M2M1Yzk4ODUifSwic2VydmljZWFjY291bnQiOnsibmFtZSI6ImRlZmF1bHQiLCJ1aWQiOiI3N2M4MWFkNy0xYmVhLTRkOTQtOWNhNS1mNWQ3ZjM2MzIzMzEifX0sIm5iZiI6MTYwNDA4Mjc5Nywic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6ZGVmYXVsdCJ9.fh9yPq8zPQR4Gms6sNpn82yppV5ONWaAVzEYnFSrOK_mM69wn51bCtdG3ARJjbBoZv6wK7bNfwSKlD3nar1QTCpyz5UKW_f_m9J7IqVdLnNIjEXhuzTv2WlxFV4VeXSYX9Q6ndUsWO-m1iKdPCkIm8sHKKv9BYVtFyhEgwSDsisX2YmseHMO8j1lpROlgrv4JvUfJ7m7tn2vV4B0WiM3djwVg2Uqv830mzZ-w0VKEuqBtUzw3zisNWa96N6DcokVebD4ZzUU2-YQPWE9ccjy0NW0frCCwFO1KiVMW9E7KTQ3qMq-B8-ZTrdV58ba-EgEnbOLsmLgp4Z_e_bmvJx4hg"
 
 // jwtProjectedDataExpired is a Projected Service Account jwt with expiration
-// set to October 19, 2018
+// set to 30 Oct 2020 18:51:26 (UTC)
 //
 // {
-//   "aud": [
-//     "kubernetes.default.svc"
-//   ],
-//   "exp": 1539903397,
-//   "iat": 1539896197,
-//   "iss": "kubernetes/serviceaccount",
-//   "kubernetes.io": {
-//     "namespace": "default",
-//     "pod": {
-//       "name": "vault",
-//       "uid": "78b924ad-d303-11e8-b14c-080027e55ea8"
-//     },
-//     "serviceaccount": {
-//       "name": "default",
-//       "uid": "b389b3b2-d302-11e8-b14c-080027e55ea8"
-//     }
-//   },
-//   "nbf": 1539896197,
-//   "sub": "system:serviceaccount:default:default"
+// 	"aud": [
+// 	  "kubernetes.default.svc"
+// 	],
+// 	"exp": 1604083886,
+// 	"iat": 1604083286,
+// 	"iss": "kubernetes/serviceaccount",
+// 	"kubernetes.io": {
+// 	  "namespace": "default",
+// 	  "pod": {
+// 		"name": "vault",
+// 		"uid": "34be4d5f-66d3-4a29-beea-ce23e51f9fb8"
+// 	  },
+// 	  "serviceaccount": {
+// 		"name": "default",
+// 		"uid": "77c81ad7-1bea-4d94-9ca5-f5d7f3632331"
+// 	  }
+// 	},
+// 	"nbf": 1604083286,
+// 	"sub": "system:serviceaccount:default:default"
 // }
-var jwtProjectedDataExpired = "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJhdWQiOlsia3ViZXJuZXRlcy5kZWZhdWx0LnN2YyJdLCJleHAiOjE1Mzk5NzA1NzUsImlhdCI6MTUzOTk2MzM3NSwiaXNzIjoia3ViZXJuZXRlcy9zZXJ2aWNlYWNjb3VudCIsImt1YmVybmV0ZXMuaW8iOnsibmFtZXNwYWNlIjoiZGVmYXVsdCIsInBvZCI6eyJuYW1lIjoidmF1bHQiLCJ1aWQiOiJiNmMyNThmNS1kM2I0LTExZTgtOGVmNC0wODAwMjdlNTVlYTgifSwic2VydmljZWFjY291bnQiOnsibmFtZSI6ImRlZmF1bHQiLCJ1aWQiOiJiMzg5YjNiMi1kMzAyLTExZTgtYjE0Yy0wODAwMjdlNTVlYTgifX0sIm5iZiI6MTUzOTk2MzM3NSwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6ZGVmYXVsdCJ9.C0waXVzwShlLM3ahJkU9LH5qcFhZ2E_p7zUCkTNf0aOtu25CpF7ARsiUty_smQhLizC5wTj7GUMzXzDSkDMh6ZJEciac6UW4g2Nz9HSh3X1DS8bvP3hX_QP_TYip7DoA4mvl7ThzFbbfmRZAfjnAdJBhKX_NxJWxEfxflYwI71CMtGAu4P7IR1Dlj5tdkUR7crQl9Q7vP4nH_s0f695RkDEJT17J6ynGYVr8VMLsHbEKEJ_JqUYFVdGnYVy-Q2hQ-4JTk-5vwug72mdrDDalSSx3KPqkIJklv0kjbLmCUPyge3cpiEvhr5M79TNHNEnlRDA5xLgMNp--HcjzXNdajQ"
+var jwtProjectedDataExpired = "eyJhbGciOiJSUzI1NiIsImtpZCI6InBKY3hrSjRxME8xdE90MFozN1ZCNi14Nk13OHhGWlN4TTlyb1B0TVFxMEEifQ.eyJhdWQiOlsia3ViZXJuZXRlcy5kZWZhdWx0LnN2YyJdLCJleHAiOjE2MDQwODM4ODYsImlhdCI6MTYwNDA4MzI4NiwiaXNzIjoia3ViZXJuZXRlcy9zZXJ2aWNlYWNjb3VudCIsImt1YmVybmV0ZXMuaW8iOnsibmFtZXNwYWNlIjoiZGVmYXVsdCIsInBvZCI6eyJuYW1lIjoidmF1bHQiLCJ1aWQiOiIzNGJlNGQ1Zi02NmQzLTRhMjktYmVlYS1jZTIzZTUxZjlmYjgifSwic2VydmljZWFjY291bnQiOnsibmFtZSI6ImRlZmF1bHQiLCJ1aWQiOiI3N2M4MWFkNy0xYmVhLTRkOTQtOWNhNS1mNWQ3ZjM2MzIzMzEifX0sIm5iZiI6MTYwNDA4MzI4Niwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6ZGVmYXVsdCJ9.dpsCBhOC-7yy47JgoSN1rCafLVR_wV9drXfRPqZotj_KszG-Oyq8zO3HmZTRM7aWqwR7X-Zna04DdnIktLuLaRvLfOMkRDJsdfzsxMlRNqaxVkJq3fRYTbJwcsM9xNiquJ16lfZmQV2VE64kYFTiN_3-kkGY05z_CvzqZcEfnKhdUTuvNXIP893rdk-72kKFa1HuWz0c6vgOOoxMf4hsoNhzgVAp5P39ZpQvZLNMhwaUcbhq55WxuaGsBcm7SNLfkT-hNG06RQXhSwo_qTXo9gZzPhG7bm4nNDh_wg7b4ORQVBe00kqiFhfyH7bBdwZliKKi3xxw43wpbC2cS8nyDA"
 
 // testMinikubePubKey is the public key of the minikube instance used to
 // generate the projected token signature for jwtProjectedData and
@@ -899,7 +910,7 @@ var jwtProjectedDataExpired = "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJhdWQiOlsia3Vi
 // To setup a minikube instance to replicate or re-generate keys if needed, use
 // this invocation:
 //
-// minikube start --kubernetes-version v1.12.1  \
+// minikube start --kubernetes-version v1.18.10  \
 //   --feature-gates="TokenRequest=true,TokenRequestProjection=true" \
 //   --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key \
 //   --extra-config=apiserver.service-account-issuer="kubernetes/serviceaccount" \
@@ -911,11 +922,11 @@ var jwtProjectedDataExpired = "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJhdWQiOlsia3Vi
 //
 var testMinikubePubKey = `
 -----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnz2IA2XKkdKqcRI1AfBi
-Q836H1vrYWjwh96m5b1TgOzZXx+xZfsZ+7csJP7Umn3Q5wlLI1rokrJHuoEoQEmQ
-lsShMkmPGEXpXctYU4rk3s6xd9Iqp6zq1kZnoPz2Q3w1k3SrcePZFEe2PaYtvdv9
-C5Y4sXsAuPACyaMtCWDVROpGD4c4V5TpenGSUR4Pv7IVeoH1rSaPc5gdkF2JDwgD
-ubAfMIRxlN3nY+KHsSGyzFuaXrLbKVI+EzDY22INN5S1qHH7ytKIM2mZ52kTRK/D
-0mZ7PLuq6qRuokHTkUiCY3y2OEcXNHroqxuiZGyUKKzYcRDO67Ai0Nqf6waCm0YC
-kQIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAygmU/WKtGT77GhHYbEmR
+DXufJVdJ3iSuooYcscFcwAUvQMpzt5Gd0kfI03dLx7o6r7z4BTeSaJ14ABPTYfAy
++U47Cf1zhlHw2pcWveRfq3lVEzlaqzD9u8ENkqBSB6guyIxM8RadiufJPHGkWPrw
+fOH7VaKwuW/T//oMmZwrFwD6DF99O02hUwwvM1B7b+E1+zvH5BdMHtEzB/32ibkX
+WKDrXOZIZAMPHZtt2MojxdGpPxiBSVODn6hw8n4hGBWuH7UABU+2h2kZI0ctxWaX
+UIX4hSHyjlKYDGEezrUP1mm7AX5pN1qrjtxasTSPPX8nZY/3HtM77n4PfYEwCrew
+rwIDAQAB
 -----END PUBLIC KEY-----`

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -840,11 +840,11 @@ func TestLoginProjectedToken(t *testing.T) {
 				}
 			}
 			if resp == nil && err != nil {
-				if tc.e != nil && tc.e.Error() != err.Error() {
-					t.Fatalf("error mismatch, expected (%s) got (%s)", tc.e, err)
-				}
 				if tc.e == nil {
 					t.Fatalf("unexpected err: (%s)", err)
+				}
+				if tc.e.Error() != err.Error() {
+					t.Fatalf("error mismatch, expected (%s) got (%s)", tc.e, err)
 				}
 			}
 		})


### PR DESCRIPTION
# Overview
The `jwtProjectedData` jwt used in the tests expired recently, so this updates it with one that expires in ~10 years. Also regenerated `jwtProjectedDataExpired`, and `testMinikubePubKey`.

Also added extra checks in the `TestLoginProjectedToken()` tests, since the error in the "projected-token-expired" case wasn't being checked, because the response is `nil`, but `err` is not.

# Design of Change
Generated with minikube, started with the flags from the test comments, and with a pod definition like this:

<details>

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: vault
spec:
  containers:
  - image: vault
    name: vault
    volumeMounts:
    - mountPath: /var/run/secrets/tokens
      name: vault-token
  serviceAccountName: default
  volumes:
  - name: vault-token
    projected:
      sources:
      - serviceAccountToken:
          path: vault-token
          expirationSeconds: 316000000
          audience: kubernetes.default.svc
```

</details>

And created the expired jwt by changing the expirationSeconds to the minimum (600):

<details>

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: vault
spec:
  containers:
  - image: vault
    name: vault
    volumeMounts:
    - mountPath: /var/run/secrets/tokens
      name: vault-token
  serviceAccountName: default
  volumes:
  - name: vault-token
    projected:
      sources:
      - serviceAccountToken:
          path: vault-token
          expirationSeconds: 600
          audience: kubernetes.default.svc
```

</details>


# Related Issues/Pull Requests


# Contributor Checklist
- [X] no docs required
- [X] CI was failing, so no extra test output needed
- [X] Backwards compatible
