### PR TITLE
Role option to set alias name to Service Account's "namespace/name" instead of uid

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -109,10 +109,14 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrPermissionDenied
 	}
 
-	displayName := fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name())
+	var name = serviceAccount.uid()
+	if role.HumanReadableAlias {
+			name = fmt.Sprintf("%s/%s", serviceAccount.namespace(), serviceAccount.name())
+	}
+
 	auth := &logical.Auth{
 		Alias: &logical.Alias{
-			Name: displayName,
+			Name: name,
 			Metadata: map[string]string{
 				"service_account_uid":         serviceAccount.uid(),
 				"service_account_name":        serviceAccount.name(),
@@ -130,7 +134,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 			"service_account_secret_name": serviceAccount.SecretName,
 			"role":                        roleName,
 		},
-		DisplayName: displayName,
+		DisplayName: fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name()),
 	}
 
 	role.PopulateTokenAuth(auth)

--- a/path_login.go
+++ b/path_login.go
@@ -109,9 +109,10 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrPermissionDenied
 	}
 
+	displayName := fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name())
 	auth := &logical.Auth{
 		Alias: &logical.Alias{
-			Name: serviceAccount.uid(),
+			Name: displayName,
 			Metadata: map[string]string{
 				"service_account_uid":         serviceAccount.uid(),
 				"service_account_name":        serviceAccount.name(),
@@ -129,7 +130,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 			"service_account_secret_name": serviceAccount.SecretName,
 			"role":                        roleName,
 		},
-		DisplayName: fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name()),
+		DisplayName: displayName,
 	}
 
 	role.PopulateTokenAuth(auth)

--- a/path_login.go
+++ b/path_login.go
@@ -111,7 +111,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 
 	var name = serviceAccount.uid()
 	if role.HumanReadableAlias {
-			name = fmt.Sprintf("%s/%s", serviceAccount.namespace(), serviceAccount.name())
+		name = fmt.Sprintf("%s/%s", serviceAccount.namespace(), serviceAccount.name())
 	}
 
 	auth := &logical.Auth{

--- a/path_role.go
+++ b/path_role.go
@@ -50,7 +50,7 @@ are allowed.`,
 					Description: "Optional Audience claim to verify in the jwt.",
 				},
 				"human_readable_alias": {
-					Type: 			 framework.TypeBool,
+					Type:        framework.TypeBool,
 					Description: `Use "Kubernete's Namespace/Service Account Name" instead of the UID for the alias name.`,
 				},
 				"policies": {

--- a/path_role.go
+++ b/path_role.go
@@ -49,6 +49,10 @@ are allowed.`,
 					Type:        framework.TypeString,
 					Description: "Optional Audience claim to verify in the jwt.",
 				},
+				"human_readable_alias" {
+					Type: 			 framework.TypeBool,
+					Description: "Use Kubernetes Namepsace/ServiceAccount instead of Service Accounts UID for Alias name"
+				},
 				"policies": {
 					Type:        framework.TypeCommaStringSlice,
 					Description: tokenutil.DeprecationText("token_policies"),
@@ -151,6 +155,8 @@ func (b *kubeAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request
 	if role.Audience != "" {
 		d["audience"] = role.Audience
 	}
+
+	d["human_readable_alias"] = role.HumanReadableAlias
 
 	role.PopulateTokenData(d)
 
@@ -300,6 +306,10 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	// optional audience field
 	if audience, ok := data.GetOk("audience"); ok {
 		role.Audience = audience.(string)
+	}
+
+	if humanReadableAlias, ok := data.GetOk("human_readable_alias"); ok {
+		role.HumanReadableAlias = humanReadableAlias.(bool)
 	}
 
 	// Store the entry.

--- a/path_role.go
+++ b/path_role.go
@@ -49,9 +49,9 @@ are allowed.`,
 					Type:        framework.TypeString,
 					Description: "Optional Audience claim to verify in the jwt.",
 				},
-				"human_readable_alias" {
+				"human_readable_alias": {
 					Type: 			 framework.TypeBool,
-					Description: "Use Kubernetes Namepsace/ServiceAccount instead of Service Accounts UID for Alias name"
+					Description: "Use Kubernetes Namepsace/ServiceAccount instead of Service Accounts UID for Alias name",
 				},
 				"policies": {
 					Type:        framework.TypeCommaStringSlice,

--- a/path_role.go
+++ b/path_role.go
@@ -332,6 +332,9 @@ type roleStorageEntry struct {
 	// Audience is an optional jwt claim to verify
 	Audience string `json:"audience" mapstructure:"audience" structs: "audience"`
 
+	// use the service accounts 'namespace/name' instead of uid for the alias name
+	HumanReadableAlias bool `json:"human_readable_alias" mapstructure:"human_readable_alias" structs:"human_readable_alias"`
+
 	// Deprecated by TokenParams
 	Policies   []string      `json:"policies" structs:"policies" mapstructure:"policies"`
 	NumUses    int           `json:"num_uses" mapstructure:"num_uses" structs:"num_uses"`

--- a/path_role.go
+++ b/path_role.go
@@ -51,7 +51,7 @@ are allowed.`,
 				},
 				"human_readable_alias": {
 					Type: 			 framework.TypeBool,
-					Description: "Use Kubernetes Namepsace/ServiceAccount instead of Service Accounts UID for Alias name",
+					Description: `Use "Kubernete's Namespace/Service Account Name" instead of the UID for the alias name.`,
 				},
 				"policies": {
 					Type:        framework.TypeCommaStringSlice,


### PR DESCRIPTION
# Overview
Adds a Role Configuration Option to allow using the `serviceAccount.namespace()/serviceAccount.name()` to be the alias name instead of the `serviceAccount.uid()`. 

This option allows tying Entities to Kubernetes service accounts, before they exists, and even after they been deleted and recreated. In a practical sense it allows deploying testing/staging namespaces and allowing vault to manage the credentials without needing to update vault with new service account uids every time a deployment occurs. 

The UI user's experience is also improved as the Entities>Alias list is now human readable. The user now knows what service account the alias is for without having to click and inspect the metadata of every single alias. Furthermore as namespaces get deleted and recreated the list of Entities and Aliases does not continue to grow. 

# Design of Change
The `path_role.go` implementation was updated to include this new option in the UI as well as visible in the `vault read|write auth/kubernetes/role/$ROLE` commands. And `path_login.go` was updated to check if the new option is true and if so use the namespace and service account name separated by a `/` instead of the uid.

The `/` was chosen over the existing `-` used in the `DisplayName` as the former is an invalid character in a Kubernetes namespace. A `.` could work as well. 

The name of the option `HumanReadableAlias` is surely not the best, any feedback on a better name is welcome. I've noticed in other parts of this plugin `disable_` seems to be the preferred flag/boolean prefix. Perhaps `DisableUidAlias`?

Finally enabling this option can open up security concerns, as a service account being deleted and recreated will correspond to the same alias and entity. Perhaps a warning should be added outlining this fact? Any suggestion on how to add such a warning would be appreciated. 

# Related Issues/Pull Requests
#39 Using `-` as the separator for `DisplayName`

# Contributor Checklist
[ x ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
This is a plugin specific option. As such it isn't clear more documentation is needed.
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
Change has been tested by using `vault write sys/plugins/catalog/auth/kubernetes sha256=$SHA256SUM command=vault-plugin-auth-kubernetes` to overwrite the builtin version on vault 1.6.2. Please indicate what information is required to show that it has been tested. 
[ x ] Backwards compatible
This change defaults to the current behavior and as such doesn't affect any existing infrastructure.
