### PR TITLE
Use the request context for Kubernetes API call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.12
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
     working_directory: /go/src/github.com/hashicorp/vault-plugin-auth-kubernetes
     steps:
       - checkout

--- a/path_login.go
+++ b/path_login.go
@@ -103,7 +103,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 	}
 
 	// look up the JWT token in the kubernetes API
-	err = serviceAccount.lookup(jwtStr, b.reviewFactory(config))
+	err = serviceAccount.lookup(ctx, jwtStr, b.reviewFactory(config))
 	if err != nil {
 		b.Logger().Error(`login unauthorized due to: ` + err.Error())
 		return nil, logical.ErrPermissionDenied
@@ -350,8 +350,8 @@ type projectedServiceAccountPod struct {
 
 // lookup calls the TokenReview API in kubernetes to verify the token and secret
 // still exist.
-func (s *serviceAccount) lookup(jwtStr string, tr tokenReviewer) error {
-	r, err := tr.Review(jwtStr, s.Audience)
+func (s *serviceAccount) lookup(ctx context.Context, jwtStr string, tr tokenReviewer) error {
+	r, err := tr.Review(ctx, jwtStr, s.Audience)
 	if err != nil {
 		return err
 	}

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -263,6 +263,33 @@ func TestLogin(t *testing.T) {
 	}
 }
 
+func TestLogin_ContextError(t *testing.T) {
+	b, storage := setupBackend(t, testDefaultPEMs, testName, testNamespace)
+
+	data := map[string]interface{}{
+		"role": "plugin-test",
+		"jwt":  jwtData,
+	}
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "login",
+		Storage:   storage,
+		Data:      data,
+		Connection: &logical.Connection{
+			RemoteAddr: "127.0.0.1",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := b.HandleRequest(ctx, req)
+	if err != context.Canceled {
+		t.Fatalf("expected context canceled error, got: %v", err)
+	}
+}
+
 func TestLogin_ECDSA_PEM(t *testing.T) {
 	b, storage := setupBackend(t, testNoPEMs, testName, testNamespace)
 


### PR DESCRIPTION
# Overview
This change uses the request's context for the TokenReview API call. This prevents a slow or blocked HTTP call going past the request's deadline.