### PR TITLE
Fix Alias lookahead for new JWT private claims

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -23,8 +23,6 @@ var (
 	// defaultJWTIssuer is used to verify the iss header on the JWT if the config doesn't specify an issuer.
 	defaultJWTIssuer = "kubernetes/serviceaccount"
 
-	uidJWTClaimKey = "kubernetes.io/serviceaccount/service-account.uid"
-
 	// errMismatchedSigningMethod is used if the certificate doesn't match the
 	// JWT's expected signing method.
 	errMismatchedSigningMethod = errors.New("invalid signing method")
@@ -141,7 +139,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 
 // aliasLookahead returns the alias object with the SA UID from the JWT
 // Claims.
-func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+func (b *kubeAuthBackend) aliasLookahead(_ context.Context, _ *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	jwtStr := data.Get("jwt").(string)
 	if len(jwtStr) == 0 {
 		return logical.ErrorResponse("missing jwt"), nil
@@ -153,8 +151,15 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 		return nil, err
 	}
 
-	saUID, ok := parsedJWT.Claims().Get(uidJWTClaimKey).(string)
-	if !ok || saUID == "" {
+	// Decode claims into a service account object
+	sa := &serviceAccount{}
+	err = mapstructure.Decode(parsedJWT.Claims(), sa)
+	if err != nil {
+		return nil, err
+	}
+
+	saUID := sa.uid()
+	if saUID == "" {
 		return nil, errors.New("could not parse UID from claims")
 	}
 
@@ -338,12 +343,12 @@ func (s *serviceAccount) namespace() string {
 }
 
 type projectedServiceToken struct {
-	Namespace      string                      `mapstructure:"namespace"`
-	Pod            *projectedServiceAccountPod `mapstructure:"pod"`
-	ServiceAccount *projectedServiceAccountPod `mapstructure:"serviceaccount"`
+	Namespace      string     `mapstructure:"namespace"`
+	Pod            *reference `mapstructure:"pod"`
+	ServiceAccount *reference `mapstructure:"serviceaccount"`
 }
 
-type projectedServiceAccountPod struct {
+type reference struct {
 	Name string `mapstructure:"name"`
 	UID  string `mapstructure:"uid"`
 }

--- a/path_login.go
+++ b/path_login.go
@@ -343,12 +343,12 @@ func (s *serviceAccount) namespace() string {
 }
 
 type projectedServiceToken struct {
-	Namespace      string     `mapstructure:"namespace"`
-	Pod            *reference `mapstructure:"pod"`
-	ServiceAccount *reference `mapstructure:"serviceaccount"`
+	Namespace      string        `mapstructure:"namespace"`
+	Pod            *k8sObjectRef `mapstructure:"pod"`
+	ServiceAccount *k8sObjectRef `mapstructure:"serviceaccount"`
 }
 
-type reference struct {
+type k8sObjectRef struct {
 	Name string `mapstructure:"name"`
 	UID  string `mapstructure:"uid"`
 }

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -878,6 +878,33 @@ func TestLoginProjectedToken(t *testing.T) {
 	}
 }
 
+func TestAliasLookAheadProjectedToken(t *testing.T) {
+	b, storage := setupBackend(t, append(testDefaultPEMs, testMinikubePubKey), "default", testNamespace)
+
+	data := map[string]interface{}{
+		"jwt": jwtProjectedData,
+	}
+
+	req := &logical.Request{
+		Operation: logical.AliasLookaheadOperation,
+		Path:      "login",
+		Storage:   storage,
+		Data:      data,
+		Connection: &logical.Connection{
+			RemoteAddr: "127.0.0.1",
+		},
+	}
+
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	if resp.Auth.Alias.Name != "77c81ad7-1bea-4d94-9ca5-f5d7f3632331" {
+		t.Fatalf("Unexpected UID: %s", resp.Auth.Alias.Name)
+	}
+}
+
 // jwtProjectedData is a Projected Service Account jwt with expiration set to
 // 05 Nov 2030 04:19:57 (UTC)
 //


### PR DESCRIPTION
# Overview
The AliasLookahead callback is broken for non-legacy service account JWTs. The login operation itself has been updated to handle the new style of private JWT claims from Kubernetes, and this PR updates AliasLookahead to use the same struct for extracting the required UID out of either type of token.

The main consumer of this method is Vault Enterprise when any Sentinel EGPs are configured, as it populates the MFA entity information using the service account's UID.

# Design of Change
Login and AliasLookahead now use the same struct to extract UID and other information from JWTs.

# Related Issues/Pull Requests
#107

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
    - Changelog will be added to the Vault repo when the change is pulled in
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
