### PR TITLE
Add support for setting an Alias' name from the k8s namespace and serviceaccount

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -15,6 +15,8 @@ const (
 	configPath = "config"
 	rolePrefix = "role/"
 
+	// aliasNameSourceUnset provides backwards compatibility with preexisting roles.
+	aliasNameSourceUnset   = ""
 	aliasNameSourceSAToken = "sa_token"
 	aliasNameSourceSAPath  = "sa_path"
 	aliasNameSourceDefault = aliasNameSourceSAToken
@@ -142,15 +144,12 @@ func (b *kubeAuthBackend) role(ctx context.Context, s logical.Storage, name stri
 	if len(role.TokenBoundCIDRs) == 0 && len(role.BoundCIDRs) > 0 {
 		role.TokenBoundCIDRs = role.BoundCIDRs
 	}
-	if role.AliasNameSource == "" {
-		role.AliasNameSource = aliasNameSourceDefault
-	}
 
 	return role, nil
 }
 
 func validateAliasNameSource(source string) error {
-	for s := range aliasNameSourceMap {
+	for _, s := range aliasNameSources {
 		if s == source {
 			return nil
 		}

--- a/backend.go
+++ b/backend.go
@@ -23,12 +23,8 @@ const (
 )
 
 var (
-	aliasNameSources = []string{aliasNameSourceSAToken, aliasNameSourceSAPath}
-	// map alias name source to its description
-	aliasNameSourceMap = map[string]string{
-		aliasNameSourceSAToken: "format: <token.uid>",
-		aliasNameSourceSAPath:  "format: <namespace>/<serviceaccount>",
-	}
+	// when adding new alias name sources make sure to update the corresponding FieldSchema description in path_role.go
+	aliasNameSources          = []string{aliasNameSourceSAToken, aliasNameSourceSAPath}
 	errInvalidAliasNameSource = fmt.Errorf(`invalid alias_name_source, must be one of: %s`, strings.Join(aliasNameSources, ", "))
 )
 
@@ -155,18 +151,6 @@ func validateAliasNameSource(source string) error {
 		}
 	}
 	return errInvalidAliasNameSource
-}
-
-func getAliasNameSourceDesc() string {
-	var desc = make([]string, len(aliasNameSources))
-	for i, s := range aliasNameSources {
-		d := aliasNameSourceMap[s]
-		if s == aliasNameSourceDefault {
-			d = d + " [default]"
-		}
-		desc[i] = fmt.Sprintf("%q (%s)", s, d)
-	}
-	return strings.Join(desc, ", ")
 }
 
 var backendHelp string = `

--- a/path_login.go
+++ b/path_login.go
@@ -107,9 +107,10 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrPermissionDenied
 	}
 
+	displayName := fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name())
 	auth := &logical.Auth{
 		Alias: &logical.Alias{
-			Name: serviceAccount.uid(),
+			Name: displayName,
 			Metadata: map[string]string{
 				"service_account_uid":         serviceAccount.uid(),
 				"service_account_name":        serviceAccount.name(),
@@ -127,7 +128,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 			"service_account_secret_name": serviceAccount.SecretName,
 			"role":                        roleName,
 		},
-		DisplayName: fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name()),
+		DisplayName: displayName,
 	}
 
 	role.PopulateTokenAuth(auth)

--- a/path_login.go
+++ b/path_login.go
@@ -108,7 +108,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 	var aliasName string
 	switch role.AliasNameSource {
 	case aliasNameSourceSAToken:
-		aliasName = serviceAccount.UID
+		aliasName = serviceAccount.uid()
 	case aliasNameSourceSAPath:
 		aliasName = fmt.Sprintf("%s/%s", serviceAccount.Namespace, serviceAccount.Name)
 	default:

--- a/path_login.go
+++ b/path_login.go
@@ -109,7 +109,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 
 	var name = serviceAccount.uid()
 	if role.HumanReadableAlias {
-			name = fmt.Sprintf("%s/%s", serviceAccount.namespace(), serviceAccount.name())
+		name = fmt.Sprintf("%s/%s", serviceAccount.namespace(), serviceAccount.name())
 	}
 
 	auth := &logical.Auth{

--- a/path_login.go
+++ b/path_login.go
@@ -73,7 +73,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, err
 	}
 	if role == nil {
-		return logical.ErrorResponse(fmt.Sprintf("invalid role name \"%s\"", roleName)), nil
+		return logical.ErrorResponse(fmt.Sprintf("invalid role name %q", roleName)), nil
 	}
 
 	// Check for a CIDR match.
@@ -187,7 +187,7 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 		return nil, err
 	}
 	if role == nil {
-		return logical.ErrorResponse(fmt.Sprintf("invalid role name \"%s\"", roleName)), nil
+		return logical.ErrorResponse(fmt.Sprintf("invalid role name %q", roleName)), nil
 	}
 
 	// Parse into JWT

--- a/path_login.go
+++ b/path_login.go
@@ -107,10 +107,14 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrPermissionDenied
 	}
 
-	displayName := fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name())
+	var name = serviceAccount.uid()
+	if role.HumanReadableAlias {
+			name = fmt.Sprintf("%s/%s", serviceAccount.namespace(), serviceAccount.name())
+	}
+
 	auth := &logical.Auth{
 		Alias: &logical.Alias{
-			Name: displayName,
+			Name: name,
 			Metadata: map[string]string{
 				"service_account_uid":         serviceAccount.uid(),
 				"service_account_name":        serviceAccount.name(),
@@ -128,7 +132,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 			"service_account_secret_name": serviceAccount.SecretName,
 			"role":                        roleName,
 		},
-		DisplayName: displayName,
+		DisplayName: fmt.Sprintf("%s-%s", serviceAccount.namespace(), serviceAccount.name()),
 	}
 
 	role.PopulateTokenAuth(auth)

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -659,7 +659,7 @@ func TestAliasLookAhead(t *testing.T) {
 				} else if resp != nil && resp.IsError() {
 					actual = resp.Error()
 				} else {
-					t.Fatalf("no error found")
+					t.Fatalf("expected error")
 				}
 
 				if tc.wantErr.Error() != actual.Error() {

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -154,7 +154,7 @@ func TestLogin(t *testing.T) {
 	if resp == nil || !resp.IsError() {
 		t.Fatal("expected error")
 	}
-	if resp.Error().Error() != "invalid role name \"plugin-test-bad\"" {
+	if resp.Error().Error() != `invalid role name "plugin-test-bad"` {
 		t.Fatalf("unexpected error: %s", resp.Error())
 	}
 
@@ -462,7 +462,7 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 	if resp == nil || !resp.IsError() {
 		t.Fatal("expected error")
 	}
-	if resp.Error().Error() != "invalid role name \"plugin-test-bad\"" {
+	if resp.Error().Error() != `invalid role name "plugin-test-bad"` {
 		t.Fatalf("unexpected error: %s", resp.Error())
 	}
 
@@ -799,7 +799,7 @@ func TestLoginIssValidation(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if err.Error() != "claim \"iss\" is invalid" {
+	if err.Error() != `claim "iss" is invalid` {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -887,7 +887,7 @@ func TestLoginProjectedToken(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	var roleNameError = fmt.Errorf("invalid role name \"%s\"", "plugin-test-x")
+	var roleNameError = fmt.Errorf("invalid role name %q", "plugin-test-x")
 
 	testCases := map[string]struct {
 		role        string

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -591,7 +591,8 @@ func TestAliasLookAhead(t *testing.T) {
 
 	// Test bad inputs
 	data := map[string]interface{}{
-		"jwt": jwtData,
+		"jwt":  jwtData,
+		"role": "plugin-test",
 	}
 
 	req := &logical.Request{
@@ -915,7 +916,8 @@ func TestAliasLookAheadProjectedToken(t *testing.T) {
 	b, storage := setupBackend(t, config)
 
 	data := map[string]interface{}{
-		"jwt": jwtProjectedData,
+		"jwt":  jwtProjectedData,
+		"role": "plugin-test",
 	}
 
 	req := &logical.Request{
@@ -933,7 +935,7 @@ func TestAliasLookAheadProjectedToken(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	if resp.Auth.Alias.Name != "77c81ad7-1bea-4d94-9ca5-f5d7f3632331" {
+	if resp.Auth.Alias.Name != testProjectedUID {
 		t.Fatalf("Unexpected UID: %s", resp.Auth.Alias.Name)
 	}
 }

--- a/path_role.go
+++ b/path_role.go
@@ -283,11 +283,11 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 	// Verify names was not empty
 	if len(role.ServiceAccountNames) == 0 {
-		return logical.ErrorResponse("\"bound_service_account_names\" can not be empty"), nil
+		return logical.ErrorResponse("%q can not be empty", "bound_service_account_names"), nil
 	}
 	// Verify * was not set with other data
 	if len(role.ServiceAccountNames) > 1 && strutil.StrListContains(role.ServiceAccountNames, "*") {
-		return logical.ErrorResponse("can not mix \"*\" with values"), nil
+		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
 	if namespaces, ok := data.GetOk("bound_service_account_namespaces"); ok {
@@ -297,11 +297,11 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 	// Verify namespaces is not empty
 	if len(role.ServiceAccountNamespaces) == 0 {
-		return logical.ErrorResponse("\"bound_service_account_namespaces\" can not be empty"), nil
+		return logical.ErrorResponse("%q can not be empty", "bound_service_account_namespaces"), nil
 	}
 	// Verify * was not set with other data
 	if len(role.ServiceAccountNamespaces) > 1 && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
-		return logical.ErrorResponse("can not mix \"*\" with values"), nil
+		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
 	// optional audience field

--- a/path_role.go
+++ b/path_role.go
@@ -50,7 +50,7 @@ are allowed.`,
 					Description: "Optional Audience claim to verify in the jwt.",
 				},
 				"human_readable_alias": {
-					Type: 			 framework.TypeBool,
+					Type:        framework.TypeBool,
 					Description: `Use "Kubernete's Namespace/Service Account Name" instead of the UID for the alias name.`,
 				},
 				"policies": {

--- a/path_role.go
+++ b/path_role.go
@@ -315,9 +315,7 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 		}
 		role.AliasNameSource = source.(string)
 	} else if role.AliasNameSource == aliasNameSourceUnset {
-		if s, ok := data.Schema["alias_name_source"]; ok {
-			role.AliasNameSource = s.Default.(string)
-		}
+		role.AliasNameSource = data.Get("alias_name_source").(string)
 	}
 
 	// Store the entry.

--- a/path_role.go
+++ b/path_role.go
@@ -157,8 +157,6 @@ func (b *kubeAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request
 		d["audience"] = role.Audience
 	}
 
-	d["alias_name_source"] = role.AliasNameSource
-
 	role.PopulateTokenData(d)
 
 	if len(role.Policies) > 0 {
@@ -179,6 +177,8 @@ func (b *kubeAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request
 	if role.NumUses > 0 {
 		d["num_uses"] = role.NumUses
 	}
+
+	d["alias_name_source"] = role.AliasNameSource
 
 	return &logical.Response{
 		Data: d,
@@ -314,6 +314,10 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 			return logical.ErrorResponse(err.Error()), nil
 		}
 		role.AliasNameSource = source.(string)
+	} else if role.AliasNameSource == aliasNameSourceUnset {
+		if s, ok := data.Schema["alias_name_source"]; ok {
+			role.AliasNameSource = s.Default.(string)
+		}
 	}
 
 	// Store the entry.

--- a/path_role.go
+++ b/path_role.go
@@ -49,6 +49,10 @@ are allowed.`,
 					Type:        framework.TypeString,
 					Description: "Optional Audience claim to verify in the jwt.",
 				},
+				"human_readable_alias" {
+					Type: 			 framework.TypeBool,
+					Description: "Use Kubernetes Namepsace/ServiceAccount instead of Service Accounts UID for Alias name"
+				},
 				"policies": {
 					Type:        framework.TypeCommaStringSlice,
 					Description: tokenutil.DeprecationText("token_policies"),
@@ -151,6 +155,8 @@ func (b *kubeAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request
 	if role.Audience != "" {
 		d["audience"] = role.Audience
 	}
+
+	d["human_readable_alias"] = role.HumanReadableAlias
 
 	role.PopulateTokenData(d)
 
@@ -300,6 +306,10 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	// optional audience field
 	if audience, ok := data.GetOk("audience"); ok {
 		role.Audience = audience.(string)
+	}
+
+	if humanReadableAlias, ok := data.GetOk("human_readable_alias"); ok {
+		role.HumanReadableAlias = humanReadableAlias.(bool)
 	}
 
 	// Store the entry.

--- a/path_role.go
+++ b/path_role.go
@@ -49,9 +49,9 @@ are allowed.`,
 					Type:        framework.TypeString,
 					Description: "Optional Audience claim to verify in the jwt.",
 				},
-				"human_readable_alias" {
+				"human_readable_alias": {
 					Type: 			 framework.TypeBool,
-					Description: "Use Kubernetes Namepsace/ServiceAccount instead of Service Accounts UID for Alias name"
+					Description: "Use Kubernetes Namepsace/ServiceAccount instead of Service Accounts UID for Alias name",
 				},
 				"policies": {
 					Type:        framework.TypeCommaStringSlice,

--- a/path_role.go
+++ b/path_role.go
@@ -332,6 +332,9 @@ type roleStorageEntry struct {
 	// Audience is an optional jwt claim to verify
 	Audience string `json:"audience" mapstructure:"audience" structs: "audience"`
 
+	// use the service accounts 'namespace/name' instead of uid for the alias name
+	HumanReadableAlias bool `json:"human_readable_alias" mapstructure:"human_readable_alias" structs:"human_readable_alias"`
+
 	// Deprecated by TokenParams
 	Policies   []string      `json:"policies" structs:"policies" mapstructure:"policies"`
 	NumUses    int           `json:"num_uses" mapstructure:"num_uses" structs:"num_uses"`

--- a/path_role.go
+++ b/path_role.go
@@ -51,7 +51,7 @@ are allowed.`,
 				},
 				"human_readable_alias": {
 					Type: 			 framework.TypeBool,
-					Description: "Use Kubernetes Namepsace/ServiceAccount instead of Service Accounts UID for Alias name",
+					Description: `Use "Kubernete's Namespace/Service Account Name" instead of the UID for the alias name.`,
 				},
 				"policies": {
 					Type:        framework.TypeCommaStringSlice,

--- a/path_role.go
+++ b/path_role.go
@@ -50,9 +50,14 @@ are allowed.`,
 					Description: "Optional Audience claim to verify in the jwt.",
 				},
 				"alias_name_source": {
-					Type:        framework.TypeString,
-					Description: fmt.Sprintf(`Source to use when deriving the Alias' name, valid choices: %s`, getAliasNameSourceDesc()),
-					Default:     aliasNameSourceDefault,
+					Type: framework.TypeString,
+					Description: fmt.Sprintf(`Source to use when deriving the Alias name.
+valid choices:
+	%q : <token.uid> e.g. 474b11b5-0f20-4f9d-8ca5-65715ab325e0 (most secure choice)
+	%q : <namespace>/<serviceaccount> e.g. vault/vault-agent
+default: %q
+`, aliasNameSourceSAToken, aliasNameSourceSAPath, aliasNameSourceDefault),
+					Default: aliasNameSourceDefault,
 				},
 				"policies": {
 					Type:        framework.TypeCommaStringSlice,

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -2,6 +2,8 @@ package kubeauth
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -35,141 +37,158 @@ func getBackend(t *testing.T) (logical.Backend, logical.Storage) {
 }
 
 func TestPath_Create(t *testing.T) {
-	b, storage := getBackend(t)
-
-	data := map[string]interface{}{
-		"bound_service_account_names":      "name",
-		"bound_service_account_namespaces": "namespace",
-		"policies":                         "test",
-		"period":                           "3s",
-		"ttl":                              "1s",
-		"num_uses":                         12,
-		"max_ttl":                          "5s",
-		"alias_name_source":                aliasNameSourceDefault,
-	}
-
-	expected := &roleStorageEntry{
-		TokenParams: tokenutil.TokenParams{
-			TokenPolicies:   []string{"test"},
-			TokenPeriod:     3 * time.Second,
-			TokenTTL:        1 * time.Second,
-			TokenMaxTTL:     5 * time.Second,
-			TokenNumUses:    12,
-			TokenBoundCIDRs: nil,
+	testCases := map[string]struct {
+		data     map[string]interface{}
+		expected *roleStorageEntry
+		wantErr  error
+	}{
+		"default": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "name",
+				"bound_service_account_namespaces": "namespace",
+				"policies":                         "test",
+				"period":                           "3s",
+				"ttl":                              "1s",
+				"num_uses":                         12,
+				"max_ttl":                          "5s",
+				"alias_name_source":                aliasNameSourceDefault,
+			},
+			expected: &roleStorageEntry{
+				TokenParams: tokenutil.TokenParams{
+					TokenPolicies:   []string{"test"},
+					TokenPeriod:     3 * time.Second,
+					TokenTTL:        1 * time.Second,
+					TokenMaxTTL:     5 * time.Second,
+					TokenNumUses:    12,
+					TokenBoundCIDRs: nil,
+				},
+				Policies:                 []string{"test"},
+				Period:                   3 * time.Second,
+				ServiceAccountNames:      []string{"name"},
+				ServiceAccountNamespaces: []string{"namespace"},
+				TTL:                      1 * time.Second,
+				MaxTTL:                   5 * time.Second,
+				NumUses:                  12,
+				BoundCIDRs:               nil,
+				AliasNameSource:          aliasNameSourceDefault,
+			},
 		},
-		Policies:                 []string{"test"},
-		Period:                   3 * time.Second,
-		ServiceAccountNames:      []string{"name"},
-		ServiceAccountNamespaces: []string{"namespace"},
-		TTL:                      1 * time.Second,
-		MaxTTL:                   5 * time.Second,
-		NumUses:                  12,
-		BoundCIDRs:               nil,
-		AliasNameSource:          aliasNameSourceDefault,
+		"alias_name_source_sa_path": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "name",
+				"bound_service_account_namespaces": "namespace",
+				"policies":                         "test",
+				"period":                           "3s",
+				"ttl":                              "1s",
+				"num_uses":                         12,
+				"max_ttl":                          "5s",
+				"alias_name_source":                aliasNameSourceSAPath,
+			},
+			expected: &roleStorageEntry{
+				TokenParams: tokenutil.TokenParams{
+					TokenPolicies:   []string{"test"},
+					TokenPeriod:     3 * time.Second,
+					TokenTTL:        1 * time.Second,
+					TokenMaxTTL:     5 * time.Second,
+					TokenNumUses:    12,
+					TokenBoundCIDRs: nil,
+				},
+				Policies:                 []string{"test"},
+				Period:                   3 * time.Second,
+				ServiceAccountNames:      []string{"name"},
+				ServiceAccountNamespaces: []string{"namespace"},
+				TTL:                      1 * time.Second,
+				MaxTTL:                   5 * time.Second,
+				NumUses:                  12,
+				BoundCIDRs:               nil,
+				AliasNameSource:          aliasNameSourceSAPath,
+			},
+		},
+		"invalid_alias_name_source": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "name",
+				"bound_service_account_namespaces": "namespace",
+				"policies":                         "test",
+				"period":                           "3s",
+				"ttl":                              "1s",
+				"num_uses":                         12,
+				"max_ttl":                          "5s",
+				"alias_name_source":                "_invalid_",
+			},
+			wantErr: errInvalidAliasNameSource,
+		},
+		"no_service_account_names": {
+			data: map[string]interface{}{
+				"policies": "test",
+			},
+			wantErr: errors.New(`"bound_service_account_names" can not be empty`),
+		},
+		"no_service_account_namespaces": {
+			data: map[string]interface{}{
+				"bound_service_account_names": "name",
+				"policies":                    "test",
+			},
+			wantErr: errors.New(`"bound_service_account_namespaces" can not be empty`),
+		},
+		"mixed_splat_values_names": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "*, test",
+				"bound_service_account_namespaces": "*",
+				"policies":                         "test",
+			},
+			wantErr: errors.New(`can not mix "*" with values`),
+		},
+		"mixed_splat_values_namespaces": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "*, test",
+				"bound_service_account_namespaces": "*",
+				"policies":                         "test",
+			},
+			wantErr: errors.New(`can not mix "*" with values`),
+		},
 	}
 
-	req := &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/plugin-test",
-		Storage:   storage,
-		Data:      data,
-	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			b, storage := getBackend(t)
+			path := fmt.Sprintf("role/%s", name)
+			req := &logical.Request{
+				Operation: logical.CreateOperation,
+				Path:      path,
+				Storage:   storage,
+				Data:      tc.data,
+			}
 
-	resp, err := b.HandleRequest(context.Background(), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
-	actual, err := b.(*kubeAuthBackend).role(context.Background(), storage, "plugin-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+			resp, err := b.HandleRequest(context.Background(), req)
 
-	if diff := deep.Equal(expected, actual); diff != nil {
-		t.Fatal(diff)
-	}
+			if tc.wantErr != nil {
+				var actual error
+				if err != nil {
+					actual = err
+				} else if resp != nil && resp.IsError() {
+					actual = resp.Error()
+				} else {
+					t.Fatalf("expected error")
+				}
 
-	// Test no service account info
-	data = map[string]interface{}{
-		"policies": "test",
-	}
+				if tc.wantErr.Error() != actual.Error() {
+					t.Fatalf("expected err %q, actual %q", tc.wantErr, actual)
+				}
+			} else {
+				if tc.wantErr == nil && (err != nil || (resp != nil && resp.IsError())) {
+					t.Fatalf("err:%s resp:%#v\n", err, resp)
+				}
 
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
+				actual, err := b.(*kubeAuthBackend).role(context.Background(), storage, name)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp != nil && !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "\"bound_service_account_names\" can not be empty" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	// Test no service account info
-	data = map[string]interface{}{
-		"bound_service_account_names": "name",
-		"policies":                    "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp != nil && !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "\"bound_service_account_namespaces\" can not be empty" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	// Test mixed "*" and values
-	data = map[string]interface{}{
-		"bound_service_account_names":      "*, test",
-		"bound_service_account_namespaces": "*",
-		"policies":                         "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "can not mix \"*\" with values" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	data = map[string]interface{}{
-		"bound_service_account_names":      "*",
-		"bound_service_account_namespaces": "*, test",
-		"policies":                         "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "can not mix \"*\" with values" {
-		t.Fatalf("unexpected err: %v", resp)
+				if diff := deep.Equal(tc.expected, actual); diff != nil {
+					t.Fatal(diff)
+				}
+			}
+		})
 	}
 }
 

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -45,6 +45,7 @@ func TestPath_Create(t *testing.T) {
 		"ttl":                              "1s",
 		"num_uses":                         12,
 		"max_ttl":                          "5s",
+		"alias_name_source":                aliasNameSourceDefault,
 	}
 
 	expected := &roleStorageEntry{

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -64,6 +64,7 @@ func TestPath_Create(t *testing.T) {
 		MaxTTL:                   5 * time.Second,
 		NumUses:                  12,
 		BoundCIDRs:               nil,
+		AliasNameSource:          aliasNameSourceDefault,
 	}
 
 	req := &logical.Request{
@@ -201,7 +202,7 @@ func TestPath_Read(t *testing.T) {
 		"token_type":                       logical.TokenTypeDefault.String(),
 		"token_explicit_max_ttl":           int64(0),
 		"token_no_default_policy":          false,
-		"human_readable_alias":             false,
+		"alias_name_source":                aliasNameSourceDefault,
 	}
 
 	req := &logical.Request{

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -201,6 +201,7 @@ func TestPath_Read(t *testing.T) {
 		"token_type":                       logical.TokenTypeDefault.String(),
 		"token_explicit_max_ttl":           int64(0),
 		"token_no_default_policy":          false,
+		"human_readable_alias":             false,
 	}
 
 	req := &logical.Request{


### PR DESCRIPTION
# Overview
This PR is a continuation of #103. Which added a new role configuration to store the `Alias.Name` in the form of `namespace/serviceaccount`. Prior to this change the `Alias.Name` would always be derived from the service account's token `uid`. 


# Design of Change
Add a new `role`s configuration `alias_name_source` to allow for setting one of the following naming formats:
- `<token.uid>` e.g. `53f8253e-6df4-4be7-adae-f566c524c02c` (remains the default)
- `<namespace>/<serviceaccount>`  e.g. `kube-system/coredns`

# Related Issues/Pull Requests
[ ] [PR #103](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pr/103)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (e.g., acceptance tests)
[X] Backwards compatible
