### PR TITLE
fix: rename token alias source to sa_uid

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -17,8 +17,8 @@ const (
 
 	// aliasNameSourceUnset provides backwards compatibility with preexisting roles.
 	aliasNameSourceUnset   = ""
-	aliasNameSourceSAUid   = "sa_uid"
-	aliasNameSourceSAPath  = "sa_path"
+	aliasNameSourceSAUid   = "serviceaccount_uid"
+	aliasNameSourceSAPath  = "serviceaccount_path"
 	aliasNameSourceDefault = aliasNameSourceSAUid
 )
 

--- a/backend.go
+++ b/backend.go
@@ -18,13 +18,13 @@ const (
 	// aliasNameSourceUnset provides backwards compatibility with preexisting roles.
 	aliasNameSourceUnset   = ""
 	aliasNameSourceSAUid   = "serviceaccount_uid"
-	aliasNameSourceSAPath  = "serviceaccount_path"
+	aliasNameSourceSAName  = "serviceaccount_name"
 	aliasNameSourceDefault = aliasNameSourceSAUid
 )
 
 var (
 	// when adding new alias name sources make sure to update the corresponding FieldSchema description in path_role.go
-	aliasNameSources          = []string{aliasNameSourceSAUid, aliasNameSourceSAPath}
+	aliasNameSources          = []string{aliasNameSourceSAUid, aliasNameSourceSAName}
 	errInvalidAliasNameSource = fmt.Errorf(`invalid alias_name_source, must be one of: %s`, strings.Join(aliasNameSources, ", "))
 )
 

--- a/backend.go
+++ b/backend.go
@@ -17,14 +17,14 @@ const (
 
 	// aliasNameSourceUnset provides backwards compatibility with preexisting roles.
 	aliasNameSourceUnset   = ""
-	aliasNameSourceSAToken = "sa_token"
+	aliasNameSourceSAUid   = "sa_uid"
 	aliasNameSourceSAPath  = "sa_path"
-	aliasNameSourceDefault = aliasNameSourceSAToken
+	aliasNameSourceDefault = aliasNameSourceSAUid
 )
 
 var (
 	// when adding new alias name sources make sure to update the corresponding FieldSchema description in path_role.go
-	aliasNameSources          = []string{aliasNameSourceSAToken, aliasNameSourceSAPath}
+	aliasNameSources          = []string{aliasNameSourceSAUid, aliasNameSourceSAPath}
 	errInvalidAliasNameSource = fmt.Errorf(`invalid alias_name_source, must be one of: %s`, strings.Join(aliasNameSources, ", "))
 )
 

--- a/path_login.go
+++ b/path_login.go
@@ -162,7 +162,7 @@ func (b *kubeAuthBackend) getAliasName(role *roleStorageEntry, serviceAccount *s
 			return "", err
 		}
 		return uid, nil
-	case aliasNameSourceSAPath:
+	case aliasNameSourceSAName:
 		return fmt.Sprintf("%s/%s", serviceAccount.Namespace, serviceAccount.Name), nil
 	default:
 		return "", fmt.Errorf("unknown alias_name_source %q", role.AliasNameSource)

--- a/path_login.go
+++ b/path_login.go
@@ -156,7 +156,7 @@ func (b *kubeAuthBackend) getFieldValueStr(data *framework.FieldData, param stri
 
 func (b *kubeAuthBackend) getAliasName(role *roleStorageEntry, serviceAccount *serviceAccount) (string, error) {
 	switch role.AliasNameSource {
-	case aliasNameSourceSAToken, aliasNameSourceUnset:
+	case aliasNameSourceSAUid, aliasNameSourceUnset:
 		uid, err := serviceAccount.uid()
 		if err != nil {
 			return "", err

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -610,14 +610,14 @@ func TestAliasLookAhead(t *testing.T) {
 			config:  defaultTestBackendConfig(),
 			wantErr: errors.New("missing jwt"),
 		},
-		"sa_token": {
+		"sa_uid": {
 			role: "plugin-test",
 			jwt:  jwtData,
 			config: &testBackendConfig{
 				pems:            testDefaultPEMs,
 				saName:          testName,
 				saNamespace:     testNamespace,
-				aliasNameSource: aliasNameSourceSAToken,
+				aliasNameSource: aliasNameSourceSAUid,
 			},
 			expectedAliasName: testUID,
 		},

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -621,14 +621,14 @@ func TestAliasLookAhead(t *testing.T) {
 			},
 			expectedAliasName: testUID,
 		},
-		"serviceaccount_path": {
+		"serviceaccount_name": {
 			role: "plugin-test",
 			jwt:  jwtData,
 			config: &testBackendConfig{
 				pems:            testDefaultPEMs,
 				saName:          testName,
 				saNamespace:     testNamespace,
-				aliasNameSource: aliasNameSourceSAPath,
+				aliasNameSource: aliasNameSourceSAName,
 			},
 			expectedAliasName: fmt.Sprintf("%s/%s", testNamespace, testName),
 		},

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -610,7 +610,7 @@ func TestAliasLookAhead(t *testing.T) {
 			config:  defaultTestBackendConfig(),
 			wantErr: errors.New("missing jwt"),
 		},
-		"sa_uid": {
+		"serviceaccount_uid": {
 			role: "plugin-test",
 			jwt:  jwtData,
 			config: &testBackendConfig{
@@ -621,7 +621,7 @@ func TestAliasLookAhead(t *testing.T) {
 			},
 			expectedAliasName: testUID,
 		},
-		"sa_path": {
+		"serviceaccount_path": {
 			role: "plugin-test",
 			jwt:  jwtData,
 			config: &testBackendConfig{

--- a/path_role.go
+++ b/path_role.go
@@ -56,7 +56,7 @@ valid choices:
 	%q : <token.uid> e.g. 474b11b5-0f20-4f9d-8ca5-65715ab325e0 (most secure choice)
 	%q : <namespace>/<serviceaccount> e.g. vault/vault-agent
 default: %q
-`, aliasNameSourceSAUid, aliasNameSourceSAPath, aliasNameSourceDefault),
+`, aliasNameSourceSAUid, aliasNameSourceSAName, aliasNameSourceDefault),
 					Default: aliasNameSourceDefault,
 				},
 				"policies": {

--- a/path_role.go
+++ b/path_role.go
@@ -56,7 +56,7 @@ valid choices:
 	%q : <token.uid> e.g. 474b11b5-0f20-4f9d-8ca5-65715ab325e0 (most secure choice)
 	%q : <namespace>/<serviceaccount> e.g. vault/vault-agent
 default: %q
-`, aliasNameSourceSAToken, aliasNameSourceSAPath, aliasNameSourceDefault),
+`, aliasNameSourceSAUid, aliasNameSourceSAPath, aliasNameSourceDefault),
 					Default: aliasNameSourceDefault,
 				},
 				"policies": {

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -73,7 +73,7 @@ func TestPath_Create(t *testing.T) {
 				AliasNameSource:          aliasNameSourceDefault,
 			},
 		},
-		"alias_name_source_sa_path": {
+		"alias_name_source_serviceaccount_path": {
 			data: map[string]interface{}{
 				"bound_service_account_names":      "name",
 				"bound_service_account_namespaces": "namespace",

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -73,7 +73,7 @@ func TestPath_Create(t *testing.T) {
 				AliasNameSource:          aliasNameSourceDefault,
 			},
 		},
-		"alias_name_source_serviceaccount_path": {
+		"alias_name_source_serviceaccount_name": {
 			data: map[string]interface{}{
 				"bound_service_account_names":      "name",
 				"bound_service_account_namespaces": "namespace",
@@ -82,7 +82,7 @@ func TestPath_Create(t *testing.T) {
 				"ttl":                              "1s",
 				"num_uses":                         12,
 				"max_ttl":                          "5s",
-				"alias_name_source":                aliasNameSourceSAPath,
+				"alias_name_source":                aliasNameSourceSAName,
 			},
 			expected: &roleStorageEntry{
 				TokenParams: tokenutil.TokenParams{
@@ -101,7 +101,7 @@ func TestPath_Create(t *testing.T) {
 				MaxTTL:                   5 * time.Second,
 				NumUses:                  12,
 				BoundCIDRs:               nil,
-				AliasNameSource:          aliasNameSourceSAPath,
+				AliasNameSource:          aliasNameSourceSAName,
 			},
 		},
 		"invalid_alias_name_source": {


### PR DESCRIPTION
# Overview
The `token` alias source naming was a bit misleading since all alias naming attributes are derived from the contents of the service account token. This PR renames the parameter to `sa_uid` to more precisely define the source for the Alias' name.

# Design of Change
Trivial refactoring.
