### PR TITLE
backport #114 release/vault-1.8.x

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -3,6 +3,7 @@ package kubeauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -12,8 +13,8 @@ import (
 )
 
 const (
-	configPath string = "config"
-	rolePrefix string = "role/"
+	configPath = "config"
+	rolePrefix = "role/"
 )
 
 // kubeAuthBackend implements logical.Backend
@@ -92,6 +93,17 @@ func (b *kubeAuthBackend) config(ctx context.Context, s logical.Storage) (*kubeC
 	}
 
 	return conf, nil
+}
+
+func (b *kubeAuthBackend) loadConfig(ctx context.Context, s logical.Storage) (*kubeConfig, error) {
+	config, err := b.config(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, errors.New("could not load backend configuration")
+	}
+	return config, nil
 }
 
 // role takes a storage backend and the name and returns the role's storage

--- a/path_login.go
+++ b/path_login.go
@@ -55,14 +55,14 @@ func pathLogin(b *kubeAuthBackend) *framework.Path {
 
 // pathLogin is used to authenticate to this backend
 func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	roleName := data.Get("role").(string)
-	if len(roleName) == 0 {
-		return logical.ErrorResponse("missing role"), nil
+	roleName, resp := b.getFieldValueStr(data, "role")
+	if resp != nil {
+		return resp, nil
 	}
 
-	jwtStr := data.Get("jwt").(string)
-	if len(jwtStr) == 0 {
-		return logical.ErrorResponse("missing jwt"), nil
+	jwtStr, resp := b.getFieldValueStr(data, "jwt")
+	if resp != nil {
+		return resp, nil
 	}
 
 	b.l.RLock()
@@ -73,7 +73,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, err
 	}
 	if role == nil {
-		return logical.ErrorResponse(fmt.Sprintf("invalid role name \"%s\"", roleName)), nil
+		return logical.ErrorResponse(fmt.Sprintf("invalid role name %q", roleName)), nil
 	}
 
 	// Check for a CIDR match.
@@ -87,15 +87,17 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		}
 	}
 
-	config, err := b.config(ctx, req.Storage)
+	config, err := b.loadConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
-	if config == nil {
-		return nil, errors.New("could not load backend configuration")
-	}
 
 	serviceAccount, err := b.parseAndValidateJWT(jwtStr, role, config)
+	if err != nil {
+		return nil, err
+	}
+
+	aliasName, err := serviceAccount.uid()
 	if err != nil {
 		return nil, err
 	}
@@ -107,11 +109,15 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrPermissionDenied
 	}
 
+	uid, err := serviceAccount.uid()
+	if err != nil {
+		return nil, err
+	}
 	auth := &logical.Auth{
 		Alias: &logical.Alias{
-			Name: serviceAccount.uid(),
+			Name: aliasName,
 			Metadata: map[string]string{
-				"service_account_uid":         serviceAccount.uid(),
+				"service_account_uid":         uid,
 				"service_account_name":        serviceAccount.name(),
 				"service_account_namespace":   serviceAccount.namespace(),
 				"service_account_secret_name": serviceAccount.SecretName,
@@ -121,7 +127,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 			"role": roleName,
 		},
 		Metadata: map[string]string{
-			"service_account_uid":         serviceAccount.uid(),
+			"service_account_uid":         uid,
 			"service_account_name":        serviceAccount.name(),
 			"service_account_namespace":   serviceAccount.namespace(),
 			"service_account_secret_name": serviceAccount.SecretName,
@@ -137,36 +143,57 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 	}, nil
 }
 
+func (b *kubeAuthBackend) getFieldValueStr(data *framework.FieldData, param string) (string, *logical.Response) {
+	val := data.Get(param).(string)
+	if len(val) == 0 {
+		return "", logical.ErrorResponse("missing %s", param)
+	}
+	return val, nil
+}
+
 // aliasLookahead returns the alias object with the SA UID from the JWT
 // Claims.
-func (b *kubeAuthBackend) aliasLookahead(_ context.Context, _ *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	jwtStr := data.Get("jwt").(string)
-	if len(jwtStr) == 0 {
-		return logical.ErrorResponse("missing jwt"), nil
+// Only JWTs matching the specified role's configuration will be accepted as valid.
+func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	roleName, resp := b.getFieldValueStr(data, "role")
+	if resp != nil {
+		return resp, nil
 	}
 
-	// Parse into JWT
-	parsedJWT, err := jws.ParseJWT([]byte(jwtStr))
+	jwtStr, resp := b.getFieldValueStr(data, "jwt")
+	if resp != nil {
+		return resp, nil
+	}
+
+	role, err := b.role(ctx, req.Storage, roleName)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return logical.ErrorResponse(fmt.Sprintf("invalid role name %q", roleName)), nil
+	}
+
+	config, err := b.loadConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
 
-	// Decode claims into a service account object
-	sa := &serviceAccount{}
-	err = mapstructure.Decode(parsedJWT.Claims(), sa)
+	// validation of the JWT against the provided role ensures alias look ahead requests
+	// are authentic.
+	sa, err := b.parseAndValidateJWT(jwtStr, role, config)
 	if err != nil {
 		return nil, err
 	}
 
-	saUID := sa.uid()
-	if saUID == "" {
-		return nil, errors.New("could not parse UID from claims")
+	aliasName, err := sa.uid()
+	if err != nil {
+		return nil, err
 	}
 
 	return &logical.Response{
 		Auth: &logical.Auth{
 			Alias: &logical.Alias{
-				Name: saUID,
+				Name: aliasName,
 			},
 		},
 	}, nil
@@ -316,11 +343,17 @@ type serviceAccount struct {
 
 // uid returns the UID for the service account, preferring the projected service
 // account value if found
-func (s *serviceAccount) uid() string {
+// return an error when the UID is empty.
+func (s *serviceAccount) uid() (string, error) {
+	uid := s.UID
 	if s.Kubernetes != nil && s.Kubernetes.ServiceAccount != nil {
-		return s.Kubernetes.ServiceAccount.UID
+		uid = s.Kubernetes.ServiceAccount.UID
 	}
-	return s.UID
+
+	if uid == "" {
+		return "", errors.New("could not parse UID from claims")
+	}
+	return uid, nil
 }
 
 // name returns the name for the service account, preferring the projected
@@ -366,7 +399,11 @@ func (s *serviceAccount) lookup(ctx context.Context, jwtStr string, tr tokenRevi
 	if s.name() != r.Name {
 		return errors.New("JWT names did not match")
 	}
-	if s.uid() != r.UID {
+	uid, err := s.uid()
+	if err != nil {
+		return err
+	}
+	if uid != r.UID {
 		return errors.New("JWT UIDs did not match")
 	}
 	if s.namespace() != r.Namespace {

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -31,18 +31,26 @@ var (
 	testNoPEMs      = []string{testECCert, testRSACert}
 )
 
-func setupBackend(t *testing.T, pems []string, saName string, saNamespace string) (logical.Backend, logical.Storage) {
-	b, storage := getBackend(t)
+type testBackendConfig struct {
+	pems        []string
+	saName      string
+	saNamespace string
+}
 
-	// pems := []string{testECCert, testRSACert, testMinikubePubKey}
-	// pems := []string{testECCert, testRSACert}
-	// if noPEMs {
-	// 	pems = []string{}
-	// }
+func defaultTestBackendConfig() *testBackendConfig {
+	return &testBackendConfig{
+		pems:        testDefaultPEMs,
+		saName:      testName,
+		saNamespace: testNamespace,
+	}
+}
+
+func setupBackend(t *testing.T, config *testBackendConfig) (logical.Backend, logical.Storage) {
+	b, storage := getBackend(t)
 
 	// test no certificate
 	data := map[string]interface{}{
-		"pem_keys":           pems,
+		"pem_keys":           config.pems,
 		"kubernetes_host":    "host",
 		"kubernetes_ca_cert": testCACert,
 	}
@@ -60,8 +68,8 @@ func setupBackend(t *testing.T, pems []string, saName string, saNamespace string
 	}
 
 	data = map[string]interface{}{
-		"bound_service_account_names":      saName,
-		"bound_service_account_namespaces": saNamespace,
+		"bound_service_account_names":      config.saName,
+		"bound_service_account_namespaces": config.saNamespace,
 		"policies":                         "test",
 		"period":                           "3s",
 		"ttl":                              "1s",
@@ -86,7 +94,7 @@ func setupBackend(t *testing.T, pems []string, saName string, saNamespace string
 }
 
 func TestLogin(t *testing.T) {
-	b, storage := setupBackend(t, testDefaultPEMs, testName, testNamespace)
+	b, storage := setupBackend(t, defaultTestBackendConfig())
 
 	// Test bad inputs
 	data := map[string]interface{}{
@@ -143,7 +151,7 @@ func TestLogin(t *testing.T) {
 	if resp == nil || !resp.IsError() {
 		t.Fatal("expected error")
 	}
-	if resp.Error().Error() != "invalid role name \"plugin-test-bad\"" {
+	if resp.Error().Error() != `invalid role name "plugin-test-bad"` {
 		t.Fatalf("unexpected error: %s", resp.Error())
 	}
 
@@ -217,7 +225,9 @@ func TestLogin(t *testing.T) {
 	}
 
 	// test successful login for globbed name
-	b, storage = setupBackend(t, testDefaultPEMs, testGlobbedName, testNamespace)
+	config := defaultTestBackendConfig()
+	config.saName = testGlobbedName
+	b, storage = setupBackend(t, config)
 
 	data = map[string]interface{}{
 		"role": "plugin-test",
@@ -240,7 +250,9 @@ func TestLogin(t *testing.T) {
 	}
 
 	// test successful login for globbed namespace
-	b, storage = setupBackend(t, testDefaultPEMs, testName, testGlobbedNamespace)
+	config = defaultTestBackendConfig()
+	config.saNamespace = testGlobbedNamespace
+	b, storage = setupBackend(t, config)
 
 	data = map[string]interface{}{
 		"role": "plugin-test",
@@ -264,7 +276,7 @@ func TestLogin(t *testing.T) {
 }
 
 func TestLogin_ContextError(t *testing.T) {
-	b, storage := setupBackend(t, testDefaultPEMs, testName, testNamespace)
+	b, storage := setupBackend(t, defaultTestBackendConfig())
 
 	data := map[string]interface{}{
 		"role": "plugin-test",
@@ -291,7 +303,9 @@ func TestLogin_ContextError(t *testing.T) {
 }
 
 func TestLogin_ECDSA_PEM(t *testing.T) {
-	b, storage := setupBackend(t, testNoPEMs, testName, testNamespace)
+	config := defaultTestBackendConfig()
+	config.pems = testNoPEMs
+	b, storage := setupBackend(t, config)
 
 	// test no certificate
 	data := map[string]interface{}{
@@ -335,7 +349,9 @@ func TestLogin_ECDSA_PEM(t *testing.T) {
 }
 
 func TestLogin_NoPEMs(t *testing.T) {
-	b, storage := setupBackend(t, testNoPEMs, testName, testNamespace)
+	config := defaultTestBackendConfig()
+	config.pems = testNoPEMs
+	b, storage := setupBackend(t, config)
 
 	// test bad jwt service account
 	data := map[string]interface{}{
@@ -383,7 +399,10 @@ func TestLogin_NoPEMs(t *testing.T) {
 }
 
 func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
-	b, storage := setupBackend(t, testDefaultPEMs, "*", "*")
+	config := defaultTestBackendConfig()
+	config.saName = "*"
+	config.saNamespace = "*"
+	b, storage := setupBackend(t, config)
 
 	// Test bad inputs
 	data := map[string]interface{}{
@@ -440,7 +459,7 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 	if resp == nil || !resp.IsError() {
 		t.Fatal("expected error")
 	}
-	if resp.Error().Error() != "invalid role name \"plugin-test-bad\"" {
+	if resp.Error().Error() != `invalid role name "plugin-test-bad"` {
 		t.Fatalf("unexpected error: %s", resp.Error())
 	}
 
@@ -514,7 +533,9 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 	}
 
 	// test successful login for globbed name
-	b, storage = setupBackend(t, testDefaultPEMs, testGlobbedName, testNamespace)
+	config = defaultTestBackendConfig()
+	config.saName = testGlobbedName
+	b, storage = setupBackend(t, config)
 
 	data = map[string]interface{}{
 		"role": "plugin-test",
@@ -537,7 +558,9 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 	}
 
 	// test successful login for globbed namespace
-	b, storage = setupBackend(t, testDefaultPEMs, testName, testGlobbedNamespace)
+	config = defaultTestBackendConfig()
+	config.saNamespace = testGlobbedNamespace
+	b, storage = setupBackend(t, config)
 
 	data = map[string]interface{}{
 		"role": "plugin-test",
@@ -561,35 +584,79 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 }
 
 func TestAliasLookAhead(t *testing.T) {
-	b, storage := setupBackend(t, testDefaultPEMs, testName, testNamespace)
-
-	// Test bad inputs
-	data := map[string]interface{}{
-		"jwt": jwtData,
-	}
-
-	req := &logical.Request{
-		Operation: logical.AliasLookaheadOperation,
-		Path:      "login",
-		Storage:   storage,
-		Data:      data,
-		Connection: &logical.Connection{
-			RemoteAddr: "127.0.0.1",
+	testCases := map[string]struct {
+		role    string
+		jwt     string
+		config  *testBackendConfig
+		wantErr error
+	}{
+		"default": {
+			role:   "plugin-test",
+			jwt:    jwtData,
+			config: defaultTestBackendConfig(),
+		},
+		"no_role": {
+			jwt:     jwtData,
+			config:  defaultTestBackendConfig(),
+			wantErr: errors.New("missing role"),
+		},
+		"no_jwt": {
+			role:    "plugin-test",
+			config:  defaultTestBackendConfig(),
+			wantErr: errors.New("missing jwt"),
+		},
+		"invalid_jwt": {
+			role:    "plugin-test",
+			config:  defaultTestBackendConfig(),
+			jwt:     jwtBadServiceAccount,
+			wantErr: errors.New("service account name not authorized"),
 		},
 	}
 
-	resp, err := b.HandleRequest(context.Background(), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			b, storage := setupBackend(t, tc.config)
 
-	if resp.Auth.Alias.Name != testUID {
-		t.Fatalf("Unexpected UID: %s", resp.Auth.Alias.Name)
+			req := &logical.Request{
+				Operation: logical.AliasLookaheadOperation,
+				Path:      "login",
+				Storage:   storage,
+				Data: map[string]interface{}{
+					"jwt":  tc.jwt,
+					"role": tc.role,
+				},
+				Connection: &logical.Connection{
+					RemoteAddr: "127.0.0.1",
+				},
+			}
+
+			resp, err := b.HandleRequest(context.Background(), req)
+			if tc.wantErr != nil {
+				var actual error
+				if err != nil {
+					actual = err
+				} else if resp != nil && resp.IsError() {
+					actual = resp.Error()
+				} else {
+					t.Fatalf("expected error")
+				}
+
+				if tc.wantErr.Error() != actual.Error() {
+					t.Fatalf("expected err %q, actual %q", tc.wantErr, actual)
+				}
+			} else {
+				if err != nil || (resp != nil && resp.IsError()) {
+					t.Fatalf("err:%s resp:%#v\n", err, resp)
+				}
+			}
+		})
 	}
 }
 
 func TestLoginIssValidation(t *testing.T) {
-	b, storage := setupBackend(t, testNoPEMs, testName, testNamespace)
+	config := defaultTestBackendConfig()
+	config.pems = testNoPEMs
+	b, storage := setupBackend(t, config)
 
 	// test iss validation enabled with default "kubernetes/serviceaccount" issuer
 	data := map[string]interface{}{
@@ -707,7 +774,7 @@ func TestLoginIssValidation(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if err.Error() != "claim \"iss\" is invalid" {
+	if err.Error() != `claim "iss" is invalid` {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -768,7 +835,9 @@ Pk9Yf9rIf374m5XP1U8q79dBhLSIuaojsvOT39UUcPJROSD1FqYLued0rXiooIii
 -----END PUBLIC KEY-----`
 
 func TestLoginProjectedToken(t *testing.T) {
-	b, storage := setupBackend(t, append(testDefaultPEMs, testMinikubePubKey), testName, testNamespace)
+	config := defaultTestBackendConfig()
+	config.pems = append(testDefaultPEMs, testMinikubePubKey)
+	b, storage := setupBackend(t, config)
 
 	// update backend to accept "default" bound account name
 	data := map[string]interface{}{
@@ -793,7 +862,7 @@ func TestLoginProjectedToken(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	var roleNameError = fmt.Errorf("invalid role name \"%s\"", "plugin-test-x")
+	var roleNameError = fmt.Errorf("invalid role name %q", "plugin-test-x")
 
 	testCases := map[string]struct {
 		role        string
@@ -879,10 +948,14 @@ func TestLoginProjectedToken(t *testing.T) {
 }
 
 func TestAliasLookAheadProjectedToken(t *testing.T) {
-	b, storage := setupBackend(t, append(testDefaultPEMs, testMinikubePubKey), "default", testNamespace)
+	config := defaultTestBackendConfig()
+	config.pems = append(testDefaultPEMs, testMinikubePubKey)
+	config.saName = "default"
+	b, storage := setupBackend(t, config)
 
 	data := map[string]interface{}{
-		"jwt": jwtProjectedData,
+		"jwt":  jwtProjectedData,
+		"role": "plugin-test",
 	}
 
 	req := &logical.Request{
@@ -900,7 +973,7 @@ func TestAliasLookAheadProjectedToken(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	if resp.Auth.Alias.Name != "77c81ad7-1bea-4d94-9ca5-f5d7f3632331" {
+	if resp.Auth.Alias.Name != testProjectedUID {
 		t.Fatalf("Unexpected UID: %s", resp.Auth.Alias.Name)
 	}
 }

--- a/path_role.go
+++ b/path_role.go
@@ -276,11 +276,11 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 	// Verify names was not empty
 	if len(role.ServiceAccountNames) == 0 {
-		return logical.ErrorResponse("\"bound_service_account_names\" can not be empty"), nil
+		return logical.ErrorResponse("%q can not be empty", "bound_service_account_names"), nil
 	}
 	// Verify * was not set with other data
 	if len(role.ServiceAccountNames) > 1 && strutil.StrListContains(role.ServiceAccountNames, "*") {
-		return logical.ErrorResponse("can not mix \"*\" with values"), nil
+		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
 	if namespaces, ok := data.GetOk("bound_service_account_namespaces"); ok {
@@ -290,11 +290,11 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 	// Verify namespaces is not empty
 	if len(role.ServiceAccountNamespaces) == 0 {
-		return logical.ErrorResponse("\"bound_service_account_namespaces\" can not be empty"), nil
+		return logical.ErrorResponse("%q can not be empty", "bound_service_account_namespaces"), nil
 	}
 	// Verify * was not set with other data
 	if len(role.ServiceAccountNamespaces) > 1 && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
-		return logical.ErrorResponse("can not mix \"*\" with values"), nil
+		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
 	// optional audience field

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -2,6 +2,8 @@ package kubeauth
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -35,139 +37,141 @@ func getBackend(t *testing.T) (logical.Backend, logical.Storage) {
 }
 
 func TestPath_Create(t *testing.T) {
-	b, storage := getBackend(t)
-
-	data := map[string]interface{}{
-		"bound_service_account_names":      "name",
-		"bound_service_account_namespaces": "namespace",
-		"policies":                         "test",
-		"period":                           "3s",
-		"ttl":                              "1s",
-		"num_uses":                         12,
-		"max_ttl":                          "5s",
-	}
-
-	expected := &roleStorageEntry{
-		TokenParams: tokenutil.TokenParams{
-			TokenPolicies:   []string{"test"},
-			TokenPeriod:     3 * time.Second,
-			TokenTTL:        1 * time.Second,
-			TokenMaxTTL:     5 * time.Second,
-			TokenNumUses:    12,
-			TokenBoundCIDRs: nil,
+	testCases := map[string]struct {
+		data     map[string]interface{}
+		expected *roleStorageEntry
+		wantErr  error
+	}{
+		"default": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "name",
+				"bound_service_account_namespaces": "namespace",
+				"policies":                         "test",
+				"period":                           "3s",
+				"ttl":                              "1s",
+				"num_uses":                         12,
+				"max_ttl":                          "5s",
+			},
+			expected: &roleStorageEntry{
+				TokenParams: tokenutil.TokenParams{
+					TokenPolicies:   []string{"test"},
+					TokenPeriod:     3 * time.Second,
+					TokenTTL:        1 * time.Second,
+					TokenMaxTTL:     5 * time.Second,
+					TokenNumUses:    12,
+					TokenBoundCIDRs: nil,
+				},
+				Policies:                 []string{"test"},
+				Period:                   3 * time.Second,
+				ServiceAccountNames:      []string{"name"},
+				ServiceAccountNamespaces: []string{"namespace"},
+				TTL:                      1 * time.Second,
+				MaxTTL:                   5 * time.Second,
+				NumUses:                  12,
+				BoundCIDRs:               nil,
+			},
 		},
-		Policies:                 []string{"test"},
-		Period:                   3 * time.Second,
-		ServiceAccountNames:      []string{"name"},
-		ServiceAccountNamespaces: []string{"namespace"},
-		TTL:                      1 * time.Second,
-		MaxTTL:                   5 * time.Second,
-		NumUses:                  12,
-		BoundCIDRs:               nil,
+		"alias_name_source_serviceaccount_name": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "name",
+				"bound_service_account_namespaces": "namespace",
+				"policies":                         "test",
+				"period":                           "3s",
+				"ttl":                              "1s",
+				"num_uses":                         12,
+				"max_ttl":                          "5s",
+			},
+			expected: &roleStorageEntry{
+				TokenParams: tokenutil.TokenParams{
+					TokenPolicies:   []string{"test"},
+					TokenPeriod:     3 * time.Second,
+					TokenTTL:        1 * time.Second,
+					TokenMaxTTL:     5 * time.Second,
+					TokenNumUses:    12,
+					TokenBoundCIDRs: nil,
+				},
+				Policies:                 []string{"test"},
+				Period:                   3 * time.Second,
+				ServiceAccountNames:      []string{"name"},
+				ServiceAccountNamespaces: []string{"namespace"},
+				TTL:                      1 * time.Second,
+				MaxTTL:                   5 * time.Second,
+				NumUses:                  12,
+				BoundCIDRs:               nil,
+			},
+		},
+		"no_service_account_names": {
+			data: map[string]interface{}{
+				"policies": "test",
+			},
+			wantErr: errors.New(`"bound_service_account_names" can not be empty`),
+		},
+		"no_service_account_namespaces": {
+			data: map[string]interface{}{
+				"bound_service_account_names": "name",
+				"policies":                    "test",
+			},
+			wantErr: errors.New(`"bound_service_account_namespaces" can not be empty`),
+		},
+		"mixed_splat_values_names": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "*, test",
+				"bound_service_account_namespaces": "*",
+				"policies":                         "test",
+			},
+			wantErr: errors.New(`can not mix "*" with values`),
+		},
+		"mixed_splat_values_namespaces": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "*, test",
+				"bound_service_account_namespaces": "*",
+				"policies":                         "test",
+			},
+			wantErr: errors.New(`can not mix "*" with values`),
+		},
 	}
 
-	req := &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/plugin-test",
-		Storage:   storage,
-		Data:      data,
-	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			b, storage := getBackend(t)
+			path := fmt.Sprintf("role/%s", name)
+			req := &logical.Request{
+				Operation: logical.CreateOperation,
+				Path:      path,
+				Storage:   storage,
+				Data:      tc.data,
+			}
 
-	resp, err := b.HandleRequest(context.Background(), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
-	actual, err := b.(*kubeAuthBackend).role(context.Background(), storage, "plugin-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+			resp, err := b.HandleRequest(context.Background(), req)
 
-	if diff := deep.Equal(expected, actual); diff != nil {
-		t.Fatal(diff)
-	}
+			if tc.wantErr != nil {
+				var actual error
+				if err != nil {
+					actual = err
+				} else if resp != nil && resp.IsError() {
+					actual = resp.Error()
+				} else {
+					t.Fatalf("expected error")
+				}
 
-	// Test no service account info
-	data = map[string]interface{}{
-		"policies": "test",
-	}
+				if tc.wantErr.Error() != actual.Error() {
+					t.Fatalf("expected err %q, actual %q", tc.wantErr, actual)
+				}
+			} else {
+				if tc.wantErr == nil && (err != nil || (resp != nil && resp.IsError())) {
+					t.Fatalf("err:%s resp:%#v\n", err, resp)
+				}
 
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
+				actual, err := b.(*kubeAuthBackend).role(context.Background(), storage, name)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp != nil && !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "\"bound_service_account_names\" can not be empty" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	// Test no service account info
-	data = map[string]interface{}{
-		"bound_service_account_names": "name",
-		"policies":                    "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp != nil && !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "\"bound_service_account_namespaces\" can not be empty" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	// Test mixed "*" and values
-	data = map[string]interface{}{
-		"bound_service_account_names":      "*, test",
-		"bound_service_account_namespaces": "*",
-		"policies":                         "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "can not mix \"*\" with values" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	data = map[string]interface{}{
-		"bound_service_account_names":      "*",
-		"bound_service_account_namespaces": "*, test",
-		"policies":                         "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "can not mix \"*\" with values" {
-		t.Fatalf("unexpected err: %v", resp)
+				if diff := deep.Equal(tc.expected, actual); diff != nil {
+					t.Fatal(diff)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This PR is backports #114 . The `AliasNameSource` feature has been removed since it is only a vault-1.9 targeted feature.

- backported dependencies (partial):
  79c7586e716c645b845dea9913c430a6beabde80
  21abc8d40de83a6a62584e606aa5dc5a5ae0ed5a
