### PR TITLE
backport #114 release/vault-1.6.x

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -3,6 +3,7 @@ package kubeauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -12,8 +13,8 @@ import (
 )
 
 const (
-	configPath string = "config"
-	rolePrefix string = "role/"
+	configPath = "config"
+	rolePrefix = "role/"
 )
 
 // kubeAuthBackend implements logical.Backend
@@ -92,6 +93,17 @@ func (b *kubeAuthBackend) config(ctx context.Context, s logical.Storage) (*kubeC
 	}
 
 	return conf, nil
+}
+
+func (b *kubeAuthBackend) loadConfig(ctx context.Context, s logical.Storage) (*kubeConfig, error) {
+	config, err := b.config(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, errors.New("could not load backend configuration")
+	}
+	return config, nil
 }
 
 // role takes a storage backend and the name and returns the role's storage

--- a/path_role.go
+++ b/path_role.go
@@ -276,11 +276,11 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 	// Verify names was not empty
 	if len(role.ServiceAccountNames) == 0 {
-		return logical.ErrorResponse("\"bound_service_account_names\" can not be empty"), nil
+		return logical.ErrorResponse("%q can not be empty", "bound_service_account_names"), nil
 	}
 	// Verify * was not set with other data
 	if len(role.ServiceAccountNames) > 1 && strutil.StrListContains(role.ServiceAccountNames, "*") {
-		return logical.ErrorResponse("can not mix \"*\" with values"), nil
+		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
 	if namespaces, ok := data.GetOk("bound_service_account_namespaces"); ok {
@@ -290,11 +290,11 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 	// Verify namespaces is not empty
 	if len(role.ServiceAccountNamespaces) == 0 {
-		return logical.ErrorResponse("\"bound_service_account_namespaces\" can not be empty"), nil
+		return logical.ErrorResponse("%q can not be empty", "bound_service_account_namespaces"), nil
 	}
 	// Verify * was not set with other data
 	if len(role.ServiceAccountNamespaces) > 1 && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
-		return logical.ErrorResponse("can not mix \"*\" with values"), nil
+		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
 	// optional audience field

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -2,6 +2,8 @@ package kubeauth
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -35,139 +37,141 @@ func getBackend(t *testing.T) (logical.Backend, logical.Storage) {
 }
 
 func TestPath_Create(t *testing.T) {
-	b, storage := getBackend(t)
-
-	data := map[string]interface{}{
-		"bound_service_account_names":      "name",
-		"bound_service_account_namespaces": "namespace",
-		"policies":                         "test",
-		"period":                           "3s",
-		"ttl":                              "1s",
-		"num_uses":                         12,
-		"max_ttl":                          "5s",
-	}
-
-	expected := &roleStorageEntry{
-		TokenParams: tokenutil.TokenParams{
-			TokenPolicies:   []string{"test"},
-			TokenPeriod:     3 * time.Second,
-			TokenTTL:        1 * time.Second,
-			TokenMaxTTL:     5 * time.Second,
-			TokenNumUses:    12,
-			TokenBoundCIDRs: nil,
+	testCases := map[string]struct {
+		data     map[string]interface{}
+		expected *roleStorageEntry
+		wantErr  error
+	}{
+		"default": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "name",
+				"bound_service_account_namespaces": "namespace",
+				"policies":                         "test",
+				"period":                           "3s",
+				"ttl":                              "1s",
+				"num_uses":                         12,
+				"max_ttl":                          "5s",
+			},
+			expected: &roleStorageEntry{
+				TokenParams: tokenutil.TokenParams{
+					TokenPolicies:   []string{"test"},
+					TokenPeriod:     3 * time.Second,
+					TokenTTL:        1 * time.Second,
+					TokenMaxTTL:     5 * time.Second,
+					TokenNumUses:    12,
+					TokenBoundCIDRs: nil,
+				},
+				Policies:                 []string{"test"},
+				Period:                   3 * time.Second,
+				ServiceAccountNames:      []string{"name"},
+				ServiceAccountNamespaces: []string{"namespace"},
+				TTL:                      1 * time.Second,
+				MaxTTL:                   5 * time.Second,
+				NumUses:                  12,
+				BoundCIDRs:               nil,
+			},
 		},
-		Policies:                 []string{"test"},
-		Period:                   3 * time.Second,
-		ServiceAccountNames:      []string{"name"},
-		ServiceAccountNamespaces: []string{"namespace"},
-		TTL:                      1 * time.Second,
-		MaxTTL:                   5 * time.Second,
-		NumUses:                  12,
-		BoundCIDRs:               nil,
+		"alias_name_source_serviceaccount_name": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "name",
+				"bound_service_account_namespaces": "namespace",
+				"policies":                         "test",
+				"period":                           "3s",
+				"ttl":                              "1s",
+				"num_uses":                         12,
+				"max_ttl":                          "5s",
+			},
+			expected: &roleStorageEntry{
+				TokenParams: tokenutil.TokenParams{
+					TokenPolicies:   []string{"test"},
+					TokenPeriod:     3 * time.Second,
+					TokenTTL:        1 * time.Second,
+					TokenMaxTTL:     5 * time.Second,
+					TokenNumUses:    12,
+					TokenBoundCIDRs: nil,
+				},
+				Policies:                 []string{"test"},
+				Period:                   3 * time.Second,
+				ServiceAccountNames:      []string{"name"},
+				ServiceAccountNamespaces: []string{"namespace"},
+				TTL:                      1 * time.Second,
+				MaxTTL:                   5 * time.Second,
+				NumUses:                  12,
+				BoundCIDRs:               nil,
+			},
+		},
+		"no_service_account_names": {
+			data: map[string]interface{}{
+				"policies": "test",
+			},
+			wantErr: errors.New(`"bound_service_account_names" can not be empty`),
+		},
+		"no_service_account_namespaces": {
+			data: map[string]interface{}{
+				"bound_service_account_names": "name",
+				"policies":                    "test",
+			},
+			wantErr: errors.New(`"bound_service_account_namespaces" can not be empty`),
+		},
+		"mixed_splat_values_names": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "*, test",
+				"bound_service_account_namespaces": "*",
+				"policies":                         "test",
+			},
+			wantErr: errors.New(`can not mix "*" with values`),
+		},
+		"mixed_splat_values_namespaces": {
+			data: map[string]interface{}{
+				"bound_service_account_names":      "*, test",
+				"bound_service_account_namespaces": "*",
+				"policies":                         "test",
+			},
+			wantErr: errors.New(`can not mix "*" with values`),
+		},
 	}
 
-	req := &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/plugin-test",
-		Storage:   storage,
-		Data:      data,
-	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			b, storage := getBackend(t)
+			path := fmt.Sprintf("role/%s", name)
+			req := &logical.Request{
+				Operation: logical.CreateOperation,
+				Path:      path,
+				Storage:   storage,
+				Data:      tc.data,
+			}
 
-	resp, err := b.HandleRequest(context.Background(), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
-	actual, err := b.(*kubeAuthBackend).role(context.Background(), storage, "plugin-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+			resp, err := b.HandleRequest(context.Background(), req)
 
-	if diff := deep.Equal(expected, actual); diff != nil {
-		t.Fatal(diff)
-	}
+			if tc.wantErr != nil {
+				var actual error
+				if err != nil {
+					actual = err
+				} else if resp != nil && resp.IsError() {
+					actual = resp.Error()
+				} else {
+					t.Fatalf("expected error")
+				}
 
-	// Test no service account info
-	data = map[string]interface{}{
-		"policies": "test",
-	}
+				if tc.wantErr.Error() != actual.Error() {
+					t.Fatalf("expected err %q, actual %q", tc.wantErr, actual)
+				}
+			} else {
+				if tc.wantErr == nil && (err != nil || (resp != nil && resp.IsError())) {
+					t.Fatalf("err:%s resp:%#v\n", err, resp)
+				}
 
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
+				actual, err := b.(*kubeAuthBackend).role(context.Background(), storage, name)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp != nil && !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "\"bound_service_account_names\" can not be empty" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	// Test no service account info
-	data = map[string]interface{}{
-		"bound_service_account_names": "name",
-		"policies":                    "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp != nil && !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "\"bound_service_account_namespaces\" can not be empty" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	// Test mixed "*" and values
-	data = map[string]interface{}{
-		"bound_service_account_names":      "*, test",
-		"bound_service_account_namespaces": "*",
-		"policies":                         "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "can not mix \"*\" with values" {
-		t.Fatalf("unexpected err: %v", resp)
-	}
-
-	data = map[string]interface{}{
-		"bound_service_account_names":      "*",
-		"bound_service_account_namespaces": "*, test",
-		"policies":                         "test",
-	}
-
-	req = &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "role/test2",
-		Storage:   storage,
-		Data:      data,
-	}
-
-	resp, err = b.HandleRequest(context.Background(), req)
-	if resp == nil || !resp.IsError() {
-		t.Fatalf("expected error")
-	}
-	if resp.Error().Error() != "can not mix \"*\" with values" {
-		t.Fatalf("unexpected err: %v", resp)
+				if diff := deep.Equal(tc.expected, actual); diff != nil {
+					t.Fatal(diff)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This PR is backports #114 . The `AliasNameSource` feature has been removed since it is only a vault-1.9 targeted feature.

- backported dependencies (partial):
  79c7586e716c645b845dea9913c430a6beabde80
  21abc8d40de83a6a62584e606aa5dc5a5ae0ed5a

This back port was cherry picked from https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/119/commits/498c8d80761bae25cdc806df3bf223bec092a888
