### PR TITLE
Do not store local service account token and CA to config.

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -33,13 +33,10 @@ var (
 	// jwtReloadPeriod is the time period how often the in-memory copy of local
 	// service account token can be used, before reading it again from disk.
 	//
-	// Background for the selected value:
-	// Service account token expiration time is configurable by Kubernetes API
-	// server parameter service-account-max-token-expiration. The token is
-	// renewed when 80% of the expiration time is reached. The lowest allowed
-	// value is 1h. Reload every of 10 minutes guarantees that we will re-read
-	// the file before expiration, even if cluster uses minimum expiration time.
-	jwtReloadPeriod = 10 * time.Minute
+	// The value is selected according to recommendation in Kubernetes 1.21 changelog:
+	// "Clients should reload the token from disk periodically (once per minute
+	// is recommended) to ensure they continue to use a valid token."
+	jwtReloadPeriod = 1 * time.Minute
 )
 
 // kubeAuthBackend implements logical.Backend

--- a/backend.go
+++ b/backend.go
@@ -155,9 +155,12 @@ func (b *kubeAuthBackend) loadConfig(ctx context.Context, s logical.Storage) (*k
 
 	// Read local JWT token unless it was not stored in config.
 	if config.TokenReviewerJWT == "" {
-		config.TokenReviewerJWT, _ = b.localSATokenReader.ReadFile()
-		// Ignore error: make best effort trying to load local JWT,
-		// otherwise the JWT submitted in login payload will be used.
+		config.TokenReviewerJWT, err = b.localSATokenReader.ReadFile()
+		if err != nil {
+			// Ignore error: make best effort trying to load local JWT,
+			// otherwise the JWT submitted in login payload will be used.
+			b.Logger().Debug("failed to read local service account token, will use client token", "error", err)
+		}
 	}
 
 	// Read local CA cert unless it was stored in config.

--- a/backend.go
+++ b/backend.go
@@ -78,8 +78,8 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 func Backend() *kubeAuthBackend {
 	b := &kubeAuthBackend{
-		localSATokenReader: newCachingFileReader(localCACertPath, jwtReloadPeriod, time.Now),
-		localCACertReader:  newCachingFileReader(localJWTPath, caReloadPeriod, time.Now),
+		localSATokenReader: newCachingFileReader(localJWTPath, jwtReloadPeriod, time.Now),
+		localCACertReader:  newCachingFileReader(localCACertPath, caReloadPeriod, time.Now),
 	}
 
 	b.Backend = &framework.Backend{

--- a/caching_file_reader.go
+++ b/caching_file_reader.go
@@ -16,7 +16,7 @@ type cachingFileReader struct {
 	ttl time.Duration
 
 	// cache is the buffer holding the in-memory copy of the file.
-	cache *cachedFile
+	cache cachedFile
 
 	l sync.RWMutex
 
@@ -47,7 +47,7 @@ func (r *cachingFileReader) ReadFile() (string, error) {
 	now := r.currentTime()
 	cache := r.cache
 	r.l.RUnlock()
-	if cache != nil && now.Before(cache.expiry) {
+	if now.Before(cache.expiry) {
 		return cache.buf, nil
 	}
 
@@ -59,7 +59,7 @@ func (r *cachingFileReader) ReadFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	r.cache = &cachedFile{
+	r.cache = cachedFile{
 		buf:    string(buf),
 		expiry: now.Add(r.ttl),
 	}

--- a/caching_file_reader_test.go
+++ b/caching_file_reader_test.go
@@ -1,0 +1,57 @@
+package kubeauth
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestCachingFileReader(t *testing.T) {
+	content1 := "before"
+	content2 := "after"
+
+	// Create temporary file.
+	f, err := ioutil.TempFile("", "testfile")
+	if err != nil {
+		t.Error(err)
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+
+	r := newCachingFileReader(f.Name(), 1*time.Second)
+
+	// Write initial content to file and check that we can read it.
+	ioutil.WriteFile(f.Name(), []byte(content1), 0644)
+	got, err := r.ReadFile()
+	if err != nil {
+		t.Error(err)
+	}
+	if got != content1 {
+		t.Errorf("got '%s', expected '%s'", got, content1)
+	}
+
+	// Write new content to the file.
+	ioutil.WriteFile(f.Name(), []byte(content2), 0644)
+
+	// Read again and check we still got the old cached content.
+	got, err = r.ReadFile()
+	if err != nil {
+		t.Error(err)
+	}
+	if got != content1 {
+		t.Errorf("got '%s', expected '%s'", got, content1)
+	}
+
+	// Wait for cache to expire.
+	time.Sleep(2 * time.Second)
+
+	// Read again and check that we got the new content.
+	got, err = r.ReadFile()
+	if err != nil {
+		t.Error(err)
+	}
+	if got != content2 {
+		t.Errorf("got '%s', expected '%s'", got, content2)
+	}
+}

--- a/path_config.go
+++ b/path_config.go
@@ -140,10 +140,10 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 		}
 	} else if len(tokenReviewer) == 0 || len(caCert) == 0 {
 		// User did not provide token or CA certificate:
-		// load local token and CA cert into memory but do not store them persistently.
+		// load local token and/or CA cert into memory but do not store them persistently.
 		b.l.Lock()
 		defer b.l.Unlock()
-		err := b.loadLocalFiles()
+		err := b.loadLocalFiles(len(tokenReviewer) == 0, len(caCert) == 0)
 		if err != nil {
 			return logical.ErrorResponse(err.Error()), nil
 		}

--- a/path_login.go
+++ b/path_login.go
@@ -180,6 +180,9 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 		return resp, nil
 	}
 
+	b.l.RLock()
+	defer b.l.RUnlock()
+
 	role, err := b.role(ctx, req.Storage, roleName)
 	if err != nil {
 		return nil, err
@@ -187,9 +190,6 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 	if role == nil {
 		return logical.ErrorResponse(fmt.Sprintf("invalid role name %q", roleName)), nil
 	}
-
-	b.l.RLock()
-	defer b.l.RUnlock()
 
 	config, err := b.loadConfig(ctx, req.Storage)
 	if err != nil {

--- a/path_login.go
+++ b/path_login.go
@@ -188,6 +188,9 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse(fmt.Sprintf("invalid role name %q", roleName)), nil
 	}
 
+	b.l.RLock()
+	defer b.l.RUnlock()
+
 	config, err := b.loadConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -97,9 +97,6 @@ func setupBackend(t *testing.T, config *testBackendConfig) (logical.Backend, log
 }
 
 func TestLogin(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	b, storage := setupBackend(t, defaultTestBackendConfig())
 
 	// Test bad inputs
@@ -282,9 +279,6 @@ func TestLogin(t *testing.T) {
 }
 
 func TestLogin_ContextError(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	b, storage := setupBackend(t, defaultTestBackendConfig())
 
 	data := map[string]interface{}{
@@ -312,9 +306,6 @@ func TestLogin_ContextError(t *testing.T) {
 }
 
 func TestLogin_ECDSA_PEM(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	config := defaultTestBackendConfig()
 	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
@@ -361,9 +352,6 @@ func TestLogin_ECDSA_PEM(t *testing.T) {
 }
 
 func TestLogin_NoPEMs(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	config := defaultTestBackendConfig()
 	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
@@ -414,9 +402,6 @@ func TestLogin_NoPEMs(t *testing.T) {
 }
 
 func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	config := defaultTestBackendConfig()
 	config.saName = "*"
 	config.saNamespace = "*"
@@ -602,9 +587,6 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 }
 
 func TestAliasLookAhead(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	testCases := map[string]struct {
 		role              string
 		jwt               string
@@ -703,9 +685,6 @@ func TestAliasLookAhead(t *testing.T) {
 }
 
 func TestLoginIssValidation(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	config := defaultTestBackendConfig()
 	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
@@ -887,9 +866,6 @@ Pk9Yf9rIf374m5XP1U8q79dBhLSIuaojsvOT39UUcPJROSD1FqYLued0rXiooIii
 -----END PUBLIC KEY-----`
 
 func TestLoginProjectedToken(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	config := defaultTestBackendConfig()
 	config.pems = append(testDefaultPEMs, testMinikubePubKey)
 	b, storage := setupBackend(t, config)
@@ -1003,9 +979,6 @@ func TestLoginProjectedToken(t *testing.T) {
 }
 
 func TestAliasLookAheadProjectedToken(t *testing.T) {
-	tearDownTestCase := setupTestCase(t)
-	defer tearDownTestCase()
-
 	config := defaultTestBackendConfig()
 	config.pems = append(testDefaultPEMs, testMinikubePubKey)
 	config.saName = "default"

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -97,6 +97,9 @@ func setupBackend(t *testing.T, config *testBackendConfig) (logical.Backend, log
 }
 
 func TestLogin(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	b, storage := setupBackend(t, defaultTestBackendConfig())
 
 	// Test bad inputs
@@ -279,6 +282,9 @@ func TestLogin(t *testing.T) {
 }
 
 func TestLogin_ContextError(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	b, storage := setupBackend(t, defaultTestBackendConfig())
 
 	data := map[string]interface{}{
@@ -306,6 +312,9 @@ func TestLogin_ContextError(t *testing.T) {
 }
 
 func TestLogin_ECDSA_PEM(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	config := defaultTestBackendConfig()
 	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
@@ -352,6 +361,9 @@ func TestLogin_ECDSA_PEM(t *testing.T) {
 }
 
 func TestLogin_NoPEMs(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	config := defaultTestBackendConfig()
 	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
@@ -402,6 +414,9 @@ func TestLogin_NoPEMs(t *testing.T) {
 }
 
 func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	config := defaultTestBackendConfig()
 	config.saName = "*"
 	config.saNamespace = "*"
@@ -587,6 +602,9 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 }
 
 func TestAliasLookAhead(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	testCases := map[string]struct {
 		role              string
 		jwt               string
@@ -685,6 +703,9 @@ func TestAliasLookAhead(t *testing.T) {
 }
 
 func TestLoginIssValidation(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	config := defaultTestBackendConfig()
 	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
@@ -866,6 +887,9 @@ Pk9Yf9rIf374m5XP1U8q79dBhLSIuaojsvOT39UUcPJROSD1FqYLued0rXiooIii
 -----END PUBLIC KEY-----`
 
 func TestLoginProjectedToken(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	config := defaultTestBackendConfig()
 	config.pems = append(testDefaultPEMs, testMinikubePubKey)
 	b, storage := setupBackend(t, config)
@@ -979,6 +1003,9 @@ func TestLoginProjectedToken(t *testing.T) {
 }
 
 func TestAliasLookAheadProjectedToken(t *testing.T) {
+	tearDownTestCase := setupTestCase(t)
+	defer tearDownTestCase()
+
 	config := defaultTestBackendConfig()
 	config.pems = append(testDefaultPEMs, testMinikubePubKey)
 	config.saName = "default"


### PR DESCRIPTION
# Overview

Kubernetes 1.21 switched to new ID tokens which are now bound to a specific pod.  When pod is deleted and recreated the old token will be invalidated and not accepted by Kubernetes API server anymore.  Tokens will also expire and Kubernetes will renew them periodically.  The new tokens cause major problem with Vault since currently, even when using local tokens, the token and CA certificate are read when the authentication method is configured and stored persistently to config. 

Kubernetes authentication backend will stop working when:
- the pod where the token happened to be copied from restarts (=pod gets recreated)
- token expires

Vault will not recover automatically, it requires reconfiguration of the authentication method.

# Design of Change

This change avoids storing local token and local CA certificate in config.  Instead, they are loaded lazily when needed and kept in memory only.  Token will also re-read periodically to facilitate token rotation and to avoid authentication failure due to expired token.

# Related Issues/Pull Requests
Fixes #121
Updates #95

# Tests
Acceptance tests pass. 
New tests added.
Manual test on Kubernetes pass..

# Backwards compatibility

I believe that previously `GET /auth/kubernetes/config` returned a copy of local CA file. This is not done anymore. The justification is that local file is not part of stored configuration.  CA file is still returned if user explicitly configured it with `POST  /auth/kubernetes/config`.


# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
Issue link https://github.com/hashicorp/vault/issues/12855
- [X] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible: see details under heading "Backwards compatibility" above
