### PR TITLE
Deprecate token issuer validation

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -57,16 +57,20 @@ extracted. Not every installation of Kubernetes exposes these keys.`,
 				},
 			},
 			"issuer": {
-				Type:        framework.TypeString,
-				Description: "Optional JWT issuer. If no issuer is specified, then this plugin will use kubernetes.io/serviceaccount as the default issuer.",
+				Type:       framework.TypeString,
+				Deprecated: true,
+				Description: `Optional JWT issuer. If no issuer is specified,
+then this plugin will use kubernetes.io/serviceaccount as the default issuer.
+(Deprecated, will be removed in a future release)`,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "JWT Issuer",
 				},
 			},
 			"disable_iss_validation": {
 				Type:        framework.TypeBool,
-				Description: "Disable JWT issuer validation. Allows to skip ISS validation.",
-				Default:     false,
+				Deprecated:  true,
+				Description: `Disable JWT issuer validation (Deprecated, will be removed in a future release)`,
+				Default:     true,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Disable JWT Issuer Validation",
 				},

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -143,7 +143,7 @@ func TestConfig(t *testing.T) {
 		PEMKeys:              []string{},
 		Host:                 "host",
 		CACert:               testCACert,
-		DisableISSValidation: false,
+		DisableISSValidation: true,
 	}
 
 	conf, err := b.(*kubeAuthBackend).config(context.Background(), storage)
@@ -185,7 +185,7 @@ func TestConfig(t *testing.T) {
 		Host:                 "host",
 		CACert:               testCACert,
 		TokenReviewerJWT:     jwtData,
-		DisableISSValidation: false,
+		DisableISSValidation: true,
 		DisableLocalCAJwt:    false,
 	}
 
@@ -227,7 +227,7 @@ func TestConfig(t *testing.T) {
 		PEMKeys:              []string{testRSACert},
 		Host:                 "host",
 		CACert:               testCACert,
-		DisableISSValidation: false,
+		DisableISSValidation: true,
 		DisableLocalCAJwt:    false,
 	}
 
@@ -274,7 +274,7 @@ func TestConfig(t *testing.T) {
 		PEMKeys:              []string{testRSACert, testECCert},
 		Host:                 "host",
 		CACert:               testCACert,
-		DisableISSValidation: false,
+		DisableISSValidation: true,
 		DisableLocalCAJwt:    false,
 	}
 
@@ -355,7 +355,7 @@ func TestConfig_LocalCaJWT(t *testing.T) {
 				Host:                 "host",
 				CACert:               testLocalCACert,
 				TokenReviewerJWT:     testLocalJWT,
-				DisableISSValidation: false,
+				DisableISSValidation: true,
 				DisableLocalCAJwt:    false,
 			},
 		},
@@ -370,7 +370,7 @@ func TestConfig_LocalCaJWT(t *testing.T) {
 				Host:                 "host",
 				CACert:               testCACert,
 				TokenReviewerJWT:     testLocalJWT,
-				DisableISSValidation: false,
+				DisableISSValidation: true,
 				DisableLocalCAJwt:    false,
 			},
 		},
@@ -385,7 +385,7 @@ func TestConfig_LocalCaJWT(t *testing.T) {
 				Host:                 "host",
 				CACert:               testLocalCACert,
 				TokenReviewerJWT:     jwtData,
-				DisableISSValidation: false,
+				DisableISSValidation: true,
 				DisableLocalCAJwt:    false,
 			},
 		},
@@ -401,7 +401,7 @@ func TestConfig_LocalCaJWT(t *testing.T) {
 				Host:                 "host",
 				CACert:               testCACert,
 				TokenReviewerJWT:     "",
-				DisableISSValidation: false,
+				DisableISSValidation: true,
 				DisableLocalCAJwt:    true,
 			},
 		},


### PR DESCRIPTION
# Overview

In Kubernetes 1.21+, the default issuer varies depending on the service account token type, and since the token review API is the authority there is no need to pre-validate the token issuer. In addition token issuer validation may cause disruptions during a Kubernetes upgrade e.g. 1.20 -> 1.21. 

# Design of Change
How was this change implemented?

Change the default value for `disable_iss_validation` to be true, and deprecate the `disable_iss_validation` and `issuer` configuration fields.

# Related Issues/Pull Requests
[ ] #125 

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[X] Backwards compatible
