### PR TITLE
Return default value for role alias_name_source instead of empty string

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -182,8 +182,11 @@ func (b *kubeAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request
 	if role.NumUses > 0 {
 		d["num_uses"] = role.NumUses
 	}
-
-	d["alias_name_source"] = role.AliasNameSource
+	if role.AliasNameSource != "" {
+		d["alias_name_source"] = role.AliasNameSource
+	} else {
+		d["alias_name_source"] = aliasNameSourceDefault
+	}
 
 	return &logical.Response{
 		Data: d,

--- a/path_role.go
+++ b/path_role.go
@@ -182,10 +182,9 @@ func (b *kubeAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request
 	if role.NumUses > 0 {
 		d["num_uses"] = role.NumUses
 	}
+	d["alias_name_source"] = aliasNameSourceDefault
 	if role.AliasNameSource != "" {
 		d["alias_name_source"] = role.AliasNameSource
-	} else {
-		d["alias_name_source"] = aliasNameSourceDefault
 	}
 
 	return &logical.Response{

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -2,6 +2,7 @@ package kubeauth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -376,5 +377,20 @@ func TestPath_Migration(t *testing.T) {
 	resp, err = b.HandleRequest(context.Background(), req)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// Get the role from storage and check that AliasNameSource is set to default value.
+	raw, err := storage.Get(context.Background(), "role/new-entry")
+	if err != nil {
+		t.Fatalf("Could not read role entry: %s\n", err)
+	}
+
+	role := &roleStorageEntry{}
+	if err := json.Unmarshal(raw.Value, role); err != nil {
+		t.Fatalf("Could not deserialize role entry: %s\n", err)
+	}
+
+	if role.AliasNameSource != aliasNameSourceDefault {
+		t.Fatalf("Unexpected AliasNameSource: %s (expected %s)\n", role.AliasNameSource, aliasNameSourceDefault)
 	}
 }


### PR DESCRIPTION
# Overview
New field [`alias_name_source`](https://www.vaultproject.io/api/auth/kubernetes#alias_name_source) was introduced to Role in Vault 1.9.0.  If Role was created with older version of Vault, the field is missing from the persisted config in storage. When user sends "Read Role" request to read the stored Role with new Vault version, it will be returned with invalid value `"alias_name_source": ""`. The reason is that the corresponding Go struct gets initialized with empty string when deserializing the stored JSON without the field.

# Design of Change
This change returns the default value `"serviceaccount_uid"` instead of empty string, which makes the returned config data valid (e.g. it can be applied back in "Create Role" request).

# Related Issues

Fixes https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/133

# Contributor Checklist
[N/A] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[N/A] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[X] Backwards compatible
