### PR TITLE
Use golang-jwt/jwt/v4 to be inline with vault.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/briankassouf/jose v0.9.2-0.20180619214549-d2569464773f
 	github.com/go-test/deep v1.0.8
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
+github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/briankassouf/jose/jws"
-	// TODO: using github.com/golang-jwt/jwt for tests only,
+	// TODO: using github.com/golang-jwt/jwt/v4 for tests only,
 	// as a part of moving away from jose we should consider standardizing
 	// on a single JWT library for tests and runtime uses.
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/briankassouf/jose/jws"
 	// TODO: using github.com/golang-jwt/jwt/v4 for tests only,
-	// as a part of moving away from jose we should consider standardizing
+	// as a part of moving away from the jose fork we should consider standardizing
 	// on a single JWT library for tests and runtime uses.
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/hashicorp/errwrap"


### PR DESCRIPTION
# Overview
This PR updates the tests to use `github.com/golang-jwt/jwt/v4` instead of the `incompatible` v3 module. This is inline with some recent changes to vault and its indirect dependencies introduced in https://github.com/hashicorp/vault/pull/14138
