### PR TITLE
VAULT-2003 Consolidate jwt/jose to use just jwt lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ fmtcheck:
 
 .PHONY: fmt
 fmt:
-	gofmt -w .
+	gofumpt -w .
 
 .PHONY: setup-kind
-# create a kind cluster for running the acceptance tests locally
+# create a kind cluster for running the integration tests locally
 setup-kind:
 	kind get clusters | grep --silent "^${KIND_CLUSTER_NAME}$$" || \
 	kind create cluster \
@@ -61,6 +61,8 @@ setup-integration-test: teardown-integration-test vault-image
 		--set injector.enabled=false \
 		--set server.extraArgs="-dev-plugin-dir=/vault/plugin_directory"
 	kubectl patch --namespace=test statefulset vault --patch-file integrationtest/vault/hostPortPatch.yaml
+	kubectl apply --namespace=test -f integrationtest/vault/tokenReviewerServiceAccount.yaml
+	kubectl apply -f integrationtest/vault/tokenReviewerBinding.yaml
 	kubectl delete --namespace=test pod vault-0
 	kubectl wait --namespace=test --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=vault
 

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,10 @@ module github.com/hashicorp/vault-plugin-auth-kubernetes
 go 1.12
 
 require (
-	github.com/briankassouf/jose v0.9.2-0.20180619214549-d2569464773f
 	github.com/go-test/deep v1.0.8
 	github.com/golang-jwt/jwt/v4 v4.3.0
-	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.0.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.1
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/go-uuid v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/briankassouf/jose v0.9.2-0.20180619214549-d2569464773f h1:ZMEzE7R0WNqgbHplzSBaYJhJi5AZWTCK9baU0ebzG6g=
-github.com/briankassouf/jose v0.9.2-0.20180619214549-d2569464773f/go.mod h1:HQhVmdUf7dBNwIIdBTivnCDxcf6IZY3/zrb+uKSJz6Y=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -2,11 +2,13 @@ package integrationtest
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/vault/api"
@@ -18,22 +20,185 @@ import (
 //   - A Kubernetes cluster in which:
 //       - it can use the `test` namespace
 //       - Vault is deployed and accessible
+//       - There is a serviceaccount called test-token-reviewer-account with access to the TokenReview API
 // See `make setup-integration-test` for manual testing.
 func TestMain(m *testing.M) {
 	if os.Getenv("INTEGRATION_TESTS") != "" {
-		cmd := exec.Command("kubectl", "exec", "--namespace=test", "vault-0", "--", "cat", "/var/run/secrets/kubernetes.io/serviceaccount/token")
-		out := &bytes.Buffer{}
-		cmd.Stdout = out
-		cmd.Stderr = out
-		if err := cmd.Run(); err != nil {
-			fmt.Println(out.String())
-			fmt.Println(err)
-			os.Exit(1)
-		}
 		os.Setenv("VAULT_ADDR", "http://127.0.0.1:38200")
 		os.Setenv("VAULT_TOKEN", "root")
-		os.Setenv("KUBERNETES_JWT", out.String())
+		os.Setenv("KUBERNETES_JWT", getKubernetesJwt())
+		os.Setenv("TOKEN_REVIEWER_JWT", getTokenReviewerJwt())
 		os.Exit(m.Run())
+	}
+}
+
+func getTokenReviewerJwt() string {
+	name := runCmd("kubectl --namespace=test get serviceaccount test-token-reviewer-account -o jsonpath={.secrets[0].name}")
+	b64token := runCmd(fmt.Sprintf("kubectl --namespace=test get secrets %s -o jsonpath={.data.token}", name))
+	token, err := base64.URLEncoding.DecodeString(b64token)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	return string(token)
+}
+
+func getKubernetesJwt() string {
+	return runCmd("kubectl exec --namespace=test vault-0 -- cat /var/run/secrets/kubernetes.io/serviceaccount/token")
+}
+
+func runCmd(command string) string {
+	parts := strings.Split(command, " ")
+	cmd := exec.Command(parts[0], parts[1:]...)
+	out := &bytes.Buffer{}
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		fmt.Println(out.String())
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	return out.String()
+}
+
+func TestSuccess(t *testing.T) {
+	// Pick up VAULT_ADDR and VAULT_TOKEN from env vars
+	client, err := api.NewClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("sys/auth/kubernetes", map[string]interface{}{
+		"type": "kubernetes-dev",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		_, err = client.Logical().Delete("sys/auth/kubernetes")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	_, err = client.Logical().Write("auth/kubernetes/config", map[string]interface{}{
+		"kubernetes_host": "https://kubernetes.default.svc.cluster.local",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/kubernetes/role/test-role", map[string]interface{}{
+		"bound_service_account_names":      "vault", // vault is the serviceaccount created by helm
+		"bound_service_account_namespaces": "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/kubernetes/login", map[string]interface{}{
+		"role": "test-role",
+		"jwt":  os.Getenv("KUBERNETES_JWT"),
+	})
+	if err != nil {
+		t.Fatalf("Expected successful login but got: %v", err)
+	}
+}
+
+func TestSuccessWithTokenReviewerJwt(t *testing.T) {
+	// Pick up VAULT_ADDR and VAULT_TOKEN from env vars
+	client, err := api.NewClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("sys/auth/kubernetes", map[string]interface{}{
+		"type": "kubernetes-dev",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		_, err = client.Logical().Delete("sys/auth/kubernetes")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	_, err = client.Logical().Write("auth/kubernetes/config", map[string]interface{}{
+		"kubernetes_host":    "https://kubernetes.default.svc.cluster.local",
+		"token_reviewer_jwt": os.Getenv("TOKEN_REVIEWER_JWT"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/kubernetes/role/test-role", map[string]interface{}{
+		"bound_service_account_names":      "vault", // vault is the serviceaccount created by helm
+		"bound_service_account_namespaces": "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/kubernetes/login", map[string]interface{}{
+		"role": "test-role",
+		"jwt":  os.Getenv("KUBERNETES_JWT"),
+	})
+	if err != nil {
+		t.Fatalf("Expected successful login but got: %v", err)
+	}
+}
+
+func TestFailWithBadTokenReviewerJwt(t *testing.T) {
+	// Pick up VAULT_ADDR and VAULT_TOKEN from env vars
+	client, err := api.NewClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("sys/auth/kubernetes", map[string]interface{}{
+		"type": "kubernetes-dev",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		_, err = client.Logical().Delete("sys/auth/kubernetes")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	_, err = client.Logical().Write("auth/kubernetes/config", map[string]interface{}{
+		"kubernetes_host":    "https://kubernetes.default.svc.cluster.local",
+		"token_reviewer_jwt": badTokenReviewerJwt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/kubernetes/role/test-role", map[string]interface{}{
+		"bound_service_account_names":      "vault", // vault is the serviceaccount created by helm
+		"bound_service_account_namespaces": "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/kubernetes/login", map[string]interface{}{
+		"role": "test-role",
+		"jwt":  os.Getenv("KUBERNETES_JWT"),
+	})
+	respErr, ok := err.(*api.ResponseError)
+	if !ok {
+		t.Fatalf("Expected api.ResponseError but was: %s", reflect.TypeOf(err).Name())
+	}
+	if respErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("Expected 403 but was %d: %s", respErr.StatusCode, respErr.Error())
 	}
 }
 
@@ -66,7 +231,7 @@ func TestUnauthorizedServiceAccountErrorCode(t *testing.T) {
 	}
 
 	_, err = client.Logical().Write("auth/kubernetes/role/test-role", map[string]interface{}{
-		"bound_service_account_names":      "test",
+		"bound_service_account_names":      "test", // this serviceaccount does not exist
 		"bound_service_account_namespaces": "test",
 	})
 	if err != nil {
@@ -82,6 +247,8 @@ func TestUnauthorizedServiceAccountErrorCode(t *testing.T) {
 		t.Fatalf("Expected api.ResponseError but was: %s", reflect.TypeOf(err).Name())
 	}
 	if respErr.StatusCode != http.StatusForbidden {
-		t.Fatalf("Expected 403 but was %d", respErr.StatusCode)
+		t.Fatalf("Expected 403 but was %d: %s", respErr.StatusCode, respErr.Error())
 	}
 }
+
+var badTokenReviewerJwt = "eyJhbGciOiJSUzI1NiIsImtpZCI6IkZza1ViNWREek8tQ05uaVk3TU5mRWZ2dEx5bzFuU0tsV3JhUU5nekhVQ28ifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNjgwODg5NjQ4LCJpYXQiOjE2NDkzNTM2NDgsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJ0ZXN0IiwicG9kIjp7Im5hbWUiOiJ2YXVsdC0wIiwidWlkIjoiYTQwNGZiMTktNWQ4MC00OTBlLTkwYjktMGJjNWE3NzA5ODdkIn0sInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJ2YXVsdCIsInVpZCI6ImI2ZTM2ZDMxLTA2MDQtNDE5MS04Y2JjLTAwYzg4ZWViZDlmOSJ9LCJ3YXJuYWZ0ZXIiOjE2NDkzNTcyNTV9LCJuYmYiOjE2NDkzNTM2NDgsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDp0ZXN0OnZhdWx0In0.hxzMpKx38rKvaWUBNEg49TioRXt_JT1Z5st4A9NeBWO2xiC8hCDgVJRWqPzejz-sYoQGhZyZcrTa0cbNRIevcR7XH4DnHd27OOzSoj198I2DAdLfw_pntzOjq35-tZhxSYXsfKH69DSpHACpu5HHUAf1aiY3B6cq5Z3gXbtaoHBocfNwvtOirGL8pTYXo1kNCkcahDPfpf3faztyUQ77v0viBKIAqwxDuGks4crqIG5jT_tOnXbb7PahwtE5cS3bMLjQb1j5oEcgq6HF4NMV46Ly479QRoXtYWWsI9OSwl4H7G9Rel3fr9q4IMdCCI5A-FLxL2Fpep9TDwrNQ3mhBQ"

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -93,6 +93,8 @@ func setupKubernetesAuth(t *testing.T, boundServiceAccountName string, kubeConfi
 		if panicErr := recover(); panicErr != nil {
 			deferred()
 			panic(panicErr)
+		} else if t.Failed() {
+			deferred()
 		}
 	}()
 

--- a/integrationtest/vault/tokenReviewerBinding.yaml
+++ b/integrationtest/vault/tokenReviewerBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-token-reviewer-account-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: test-token-reviewer-account
+  namespace: test

--- a/integrationtest/vault/tokenReviewerServiceAccount.yaml
+++ b/integrationtest/vault/tokenReviewerServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-token-reviewer-account
+  namespace: test

--- a/path_config.go
+++ b/path_config.go
@@ -133,7 +133,7 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 
 	if tokenReviewer != "" {
 		// Validate it's a JWT, but don't verify the signature, since we may not have the right cert.
-		_, _, err := jwt.NewParser().ParseUnverified(tokenReviewer, &jwt.MapClaims{})
+		_, _, err := jwt.NewParser().ParseUnverified(tokenReviewer, jwt.MapClaims{})
 		if err != nil {
 			return nil, err
 		}

--- a/path_config.go
+++ b/path_config.go
@@ -8,7 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 
-	"github.com/briankassouf/jose/jws"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -132,8 +132,8 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 	tokenReviewer := data.Get("token_reviewer_jwt").(string)
 
 	if tokenReviewer != "" {
-		// Validate it's a JWT
-		_, err := jws.ParseJWT([]byte(tokenReviewer))
+		// Validate it's a JWT, but don't verify the signature, since we may not have the right cert.
+		_, _, err := jwt.NewParser().ParseUnverified(tokenReviewer, &jwt.MapClaims{})
 		if err != nil {
 			return nil, err
 		}
@@ -222,10 +222,12 @@ func parsePublicKeyPEM(data []byte) (interface{}, error) {
 	return nil, errors.New("data does not contain any valid RSA or ECDSA public keys")
 }
 
-const confHelpSyn = `Configures the JWT Public Key and Kubernetes API information.`
-const confHelpDesc = `
+const (
+	confHelpSyn  = `Configures the JWT Public Key and Kubernetes API information.`
+	confHelpDesc = `
 The Kubernetes Auth backend validates service account JWTs and verifies their
 existence with the Kubernetes TokenReview API. This endpoint configures the
 public key used to validate the JWT signature and the necessary information to
 access the Kubernetes API.
 `
+)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -160,11 +160,6 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	cert, err := parsePublicKeyPEM([]byte(testRSACert))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	expected := &kubeConfig{
 		PublicKeys:           []interface{}{},
 		PEMKeys:              []string{},
@@ -201,7 +196,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	cert, err = parsePublicKeyPEM([]byte(testRSACert))
+	cert, err := parsePublicKeyPEM([]byte(testRSACert))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -538,7 +533,6 @@ func TestConfig_LocalJWTRenewal(t *testing.T) {
 	if conf.TokenReviewerJWT != token2 {
 		t.Fatalf("got unexpected JWT: expected %#v\n got %#v\n", token2, conf.TokenReviewerJWT)
 	}
-
 }
 
 var testLocalCACert string = `-----BEGIN CERTIFICATE-----

--- a/path_login.go
+++ b/path_login.go
@@ -2,17 +2,13 @@ package kubeauth
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 
-	"github.com/briankassouf/jose/crypto"
-	"github.com/briankassouf/jose/jws"
-	"github.com/briankassouf/jose/jwt"
-	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-multierror"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
@@ -94,7 +90,10 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 	}
 
 	serviceAccount, err := b.parseAndValidateJWT(jwtStr, role, config)
-	if err != nil {
+	if err == jwt.ErrSignatureInvalid {
+		b.Logger().Error(`login unauthorized due to: ` + err.Error())
+		return nil, logical.ErrPermissionDenied
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -222,129 +221,98 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 	}, nil
 }
 
+// parseAndVerifySignature parses the JWT token validating the signature against
+// any of the keys passed in.
+func parseAndVerifySignature(token string, keys ...interface{}) (*jwt.Token, error) {
+	for _, k := range keys {
+		result, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
+			return k, nil
+		})
+		if result != nil && err == nil {
+			return result, nil
+		}
+		if err != nil && strings.ToLower(err.Error()) == "token is expired" {
+			return nil, err
+		}
+		// otherwise, try the next key
+	}
+	return nil, jwt.ErrSignatureInvalid
+}
+
 // parseAndValidateJWT is used to parse, validate and lookup the JWT token.
 func (b *kubeAuthBackend) parseAndValidateJWT(jwtStr string, role *roleStorageEntry, config *kubeConfig) (*serviceAccount, error) {
 	// Parse into JWT
-	parsedJWT, err := jws.ParseJWT([]byte(jwtStr))
+	var token *jwt.Token
+	var err error
+	if len(config.PublicKeys) == 0 {
+		// we don't verify the signature if we aren't configured with public keys
+		token, _, err = jwt.NewParser().ParseUnverified(jwtStr, jwt.MapClaims{})
+	} else {
+		token, err = parseAndVerifySignature(jwtStr, config.PublicKeys...)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// do default claims validation (expiration, issued at, not before)
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("unsupported JWT claims type: %v %v", reflect.TypeOf(token.Claims), token.Claims)
+	}
+	err = claims.Valid()
 	if err != nil {
 		return nil, err
 	}
 
 	sa := &serviceAccount{}
 
-	validator := &jwt.Validator{
-		Fn: func(c jwt.Claims) error {
-			// Decode claims into a service account object
-			err := mapstructure.Decode(c, sa)
-			if err != nil {
-				return err
-			}
+	// Decode claims into a service account object
+	err = mapstructure.Decode(token.Claims, sa)
+	if err != nil {
+		return nil, err
+	}
 
-			// verify the namespace is allowed
-			if len(role.ServiceAccountNamespaces) > 1 || role.ServiceAccountNamespaces[0] != "*" {
-				if !strutil.StrListContainsGlob(role.ServiceAccountNamespaces, sa.namespace()) {
-					return logical.CodedError(http.StatusForbidden, "namespace not authorized")
-				}
-			}
+	// verify the namespace is allowed
+	if len(role.ServiceAccountNamespaces) > 1 || role.ServiceAccountNamespaces[0] != "*" {
+		if !strutil.StrListContainsGlob(role.ServiceAccountNamespaces, sa.namespace()) {
+			return nil, logical.CodedError(http.StatusForbidden, "namespace not authorized")
+		}
+	}
 
-			// verify the service account name is allowed
-			if len(role.ServiceAccountNames) > 1 || role.ServiceAccountNames[0] != "*" {
-				if !strutil.StrListContainsGlob(role.ServiceAccountNames, sa.name()) {
-					return logical.CodedError(http.StatusForbidden, "service account name not authorized")
-				}
-			}
-
-			return nil
-		},
+	// verify the service account name is allowed
+	if len(role.ServiceAccountNames) > 1 || role.ServiceAccountNames[0] != "*" {
+		if !strutil.StrListContainsGlob(role.ServiceAccountNames, sa.name()) {
+			return nil, logical.CodedError(http.StatusForbidden,
+				fmt.Sprintf("service account name not authorized"))
+		}
 	}
 
 	// perform ISS Claim validation if configured
 	if !config.DisableISSValidation {
 		// set the expected issuer to the default kubernetes issuer if the config doesn't specify it
 		if config.Issuer != "" {
-			validator.SetIssuer(config.Issuer)
+			if !claims.VerifyIssuer(config.Issuer, true) {
+				return nil, logical.CodedError(http.StatusForbidden, "invalid token issuer")
+			}
 		} else {
-			validator.SetIssuer(defaultJWTIssuer)
+			if !claims.VerifyIssuer(defaultJWTIssuer, true) {
+				return nil, logical.CodedError(http.StatusForbidden, "invalid token issuer")
+			}
 		}
 	}
 
 	// validate the audience if the role expects it
 	if role.Audience != "" {
-		validator.SetAudience(role.Audience)
+		if !claims.VerifyAudience(role.Audience, true) {
+			return nil, logical.CodedError(http.StatusForbidden, "invalid audience")
+		}
 	}
-
-	if err := validator.Validate(parsedJWT); err != nil {
-		return nil, err
-	}
-
 	// If we don't have any public keys to verify, return the sa and end early.
 	if len(config.PublicKeys) == 0 {
 		return sa, nil
 	}
 
-	// verifyFunc is called for each certificate that is configured in the
-	// backend until one of the certificates succeeds.
-	verifyFunc := func(cert interface{}) error {
-		// Parse Headers and verify the signing method matches the public key type
-		// configured. This is done in its own scope since we don't need most of
-		// these variables later.
-		var signingMethod crypto.SigningMethod
-		{
-			parsedJWS, err := jws.Parse([]byte(jwtStr))
-			if err != nil {
-				return err
-			}
-			headers := parsedJWS.Protected()
-
-			var algStr string
-			if headers.Has("alg") {
-				algStr = headers.Get("alg").(string)
-			} else {
-				return errors.New("provided JWT must have 'alg' header value")
-			}
-
-			signingMethod = jws.GetSigningMethod(algStr)
-			switch signingMethod.(type) {
-			case *crypto.SigningMethodECDSA:
-				if _, ok := cert.(*ecdsa.PublicKey); !ok {
-					return errMismatchedSigningMethod
-				}
-			case *crypto.SigningMethodRSA:
-				if _, ok := cert.(*rsa.PublicKey); !ok {
-					return errMismatchedSigningMethod
-				}
-			default:
-				return errors.New("unsupported JWT signing method")
-			}
-		}
-
-		// validates the signature and then runs the claim validation
-		if err := parsedJWT.Validate(cert, signingMethod); err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	var validationErr error
-	// for each configured certificate run the verifyFunc
-	for _, cert := range config.PublicKeys {
-		err := verifyFunc(cert)
-		switch err {
-		case nil:
-			return sa, nil
-		case rsa.ErrVerification, crypto.ErrECDSAVerification, errMismatchedSigningMethod:
-			// if the error is a failure to verify or a signing method mismatch
-			// continue onto the next cert, storing the error to be returned if
-			// this is the last cert.
-			validationErr = multierror.Append(validationErr, errwrap.Wrapf("failed to validate JWT: {{err}}", err))
-			continue
-		default:
-			return nil, err
-		}
-	}
-
-	return nil, validationErr
+	return sa, nil
 }
 
 // serviceAccount holds the metadata from the JWT token and is used to lookup
@@ -464,7 +432,9 @@ func (b *kubeAuthBackend) pathLoginRenew() framework.OperationFunc {
 	}
 }
 
-const pathLoginHelpSyn = `Authenticates Kubernetes service accounts with Vault.`
-const pathLoginHelpDesc = `
+const (
+	pathLoginHelpSyn  = `Authenticates Kubernetes service accounts with Vault.`
+	pathLoginHelpDesc = `
 Authenticate Kubernetes service accounts.
 `
+)

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -206,7 +206,7 @@ func TestLogin(t *testing.T) {
 	resp, err = b.HandleRequest(context.Background(), req)
 	if err == nil {
 		t.Fatalf("Expected error")
-	} else if err.Error() != "permission denied" {
+	} else if !errors.Is(err, logical.ErrPermissionDenied) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -488,7 +488,7 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if err.Error() != "permission denied" {
+	if !errors.Is(logical.ErrPermissionDenied, err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -510,7 +510,7 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 	resp, err = b.HandleRequest(context.Background(), req)
 	if err == nil {
 		t.Fatalf("Expected error")
-	} else if err.Error() != "permission denied" {
+	} else if !errors.Is(logical.ErrPermissionDenied, err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -11,13 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/briankassouf/jose/jws"
-	// TODO: using github.com/golang-jwt/jwt/v4 for tests only,
-	// as a part of moving away from the jose fork we should consider standardizing
-	// on a single JWT library for tests and runtime uses.
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
@@ -41,7 +35,6 @@ var (
 	testProjectedMockFactory = mockTokenReviewFactory(testProjectedName, testNamespace, testProjectedUID)
 
 	testDefaultPEMs = []string{testECCert, testRSACert}
-	testNoPEMs      = []string{testECCert, testRSACert}
 )
 
 type testBackendConfig struct {
@@ -212,11 +205,8 @@ func TestLogin(t *testing.T) {
 
 	resp, err = b.HandleRequest(context.Background(), req)
 	if err == nil {
-		t.Fatal("expected error")
-	}
-	var expectedErr error
-	expectedErr = multierror.Append(expectedErr, errwrap.Wrapf("failed to validate JWT: {{err}}", errMismatchedSigningMethod), errwrap.Wrapf("failed to validate JWT: {{err}}", rsa.ErrVerification))
-	if err.Error() != expectedErr.Error() {
+		t.Fatalf("Expected error")
+	} else if err.Error() != "permission denied" {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -321,7 +311,6 @@ func TestLogin_ContextError(t *testing.T) {
 
 func TestLogin_ECDSA_PEM(t *testing.T) {
 	config := defaultTestBackendConfig()
-	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
 
 	// test no certificate
@@ -367,7 +356,6 @@ func TestLogin_ECDSA_PEM(t *testing.T) {
 
 func TestLogin_NoPEMs(t *testing.T) {
 	config := defaultTestBackendConfig()
-	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
 
 	// test bad jwt service account
@@ -521,11 +509,8 @@ func TestLoginSvcAcctAndNamespaceSplats(t *testing.T) {
 
 	resp, err = b.HandleRequest(context.Background(), req)
 	if err == nil {
-		t.Fatal("expected error")
-	}
-	var expectedErr error
-	expectedErr = multierror.Append(expectedErr, errwrap.Wrapf("failed to validate JWT: {{err}}", errMismatchedSigningMethod), errwrap.Wrapf("failed to validate JWT: {{err}}", rsa.ErrVerification))
-	if err.Error() != expectedErr.Error() {
+		t.Fatalf("Expected error")
+	} else if err.Error() != "permission denied" {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -717,7 +702,6 @@ func TestAliasLookAhead(t *testing.T) {
 
 func TestLoginIssValidation(t *testing.T) {
 	config := defaultTestBackendConfig()
-	config.pems = testNoPEMs
 	b, storage := setupBackend(t, config)
 
 	// test iss validation enabled with default "kubernetes/serviceaccount" issuer
@@ -761,6 +745,7 @@ func TestLoginIssValidation(t *testing.T) {
 		"kubernetes_ca_cert":     testCACert,
 		"disable_iss_validation": false,
 		"issuer":                 "kubernetes/serviceaccount",
+		"pem_keys":               testDefaultPEMs,
 	}
 
 	req = &logical.Request{
@@ -802,6 +787,7 @@ func TestLoginIssValidation(t *testing.T) {
 		"kubernetes_ca_cert":     testCACert,
 		"disable_iss_validation": false,
 		"issuer":                 "custom-issuer",
+		"pem_keys":               testDefaultPEMs,
 	}
 
 	req = &logical.Request{
@@ -836,7 +822,7 @@ func TestLoginIssValidation(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if err.Error() != `claim "iss" is invalid` {
+	if err.Error() != `invalid token issuer` {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -846,6 +832,7 @@ func TestLoginIssValidation(t *testing.T) {
 		"kubernetes_ca_cert":     testCACert,
 		"disable_iss_validation": true,
 		"issuer":                 "custom-issuer",
+		"pem_keys":               testDefaultPEMs,
 	}
 
 	req = &logical.Request{
@@ -924,7 +911,7 @@ func TestLoginProjectedToken(t *testing.T) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
-	var roleNameError = fmt.Errorf("invalid role name %q", "plugin-test-x")
+	roleNameError := fmt.Errorf("invalid role name %q", "plugin-test-x")
 
 	testCases := map[string]struct {
 		role        string
@@ -952,7 +939,7 @@ func TestLoginProjectedToken(t *testing.T) {
 			role:        "plugin-test",
 			jwt:         jwtProjectedDataExpired,
 			tokenReview: testProjectedMockFactory,
-			e:           errors.New("token is expired"), // jwt.ErrTokenIsExpired,
+			e:           errors.New("Token is expired"),
 		},
 		"projected-token-invalid-role": {
 			role:        "plugin-test-x",
@@ -964,7 +951,6 @@ func TestLoginProjectedToken(t *testing.T) {
 
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-
 			data := map[string]interface{}{
 				"role": tc.role,
 				"jwt":  tc.jwt,
@@ -1286,13 +1272,14 @@ func Test_kubeAuthBackend_getAliasName(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			parsedJWT, err := jws.ParseJWT([]byte(s))
+			claims := jwt.MapClaims{}
+			_, _, err = jwt.NewParser().ParseUnverified(s, &claims)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			sa := &serviceAccount{}
-			if err := mapstructure.Decode(parsedJWT.Claims(), sa); err != nil {
+			if err := mapstructure.Decode(claims, sa); err != nil {
 				t.Fatal(err)
 			}
 

--- a/token_review.go
+++ b/token_review.go
@@ -46,7 +46,6 @@ func tokenReviewAPIFactory(config *kubeConfig) tokenReviewer {
 }
 
 func (t *tokenReviewAPI) Review(ctx context.Context, jwt string, aud []string) (*tokenReviewResult, error) {
-
 	client := cleanhttp.DefaultClient()
 
 	// If we have a CA cert build the TLSConfig


### PR DESCRIPTION
# Overview

* Remove `jose` library direct dependency
* Add additional integration tests to cover more cases
* Switch to gofumpt to match vault

This mostly pays down technical debt and should hopefully make it easier to work with our JWT code moving forward.

This should cause minimal user-facing changes (notably there might be slight differences in the status code messages when signatures are invalid).

# Related Issues/Pull Requests
* #30
* #33

# Contributor Checklist
* [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet (no user-facing changes made)
* [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
* [x] Backwards compatible