### PR TITLE
Remove cert and pem enforcement

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -178,7 +178,7 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 
 		b.httpClient.Transport.(*http.Transport).TLSClientConfig = tlsConfig
 	}
-	
+
 	var err error
 	for i, pem := range pemList {
 		config.PublicKeys[i], err = parsePublicKeyPEM([]byte(pem))

--- a/path_config.go
+++ b/path_config.go
@@ -57,7 +57,9 @@ extracted. Not every installation of Kubernetes exposes these keys.`,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Service account verification keys",
 				},
+				Required: false,
 			},
+
 			"issuer": {
 				Type:       framework.TypeString,
 				Deprecated: true,

--- a/path_config.go
+++ b/path_config.go
@@ -37,6 +37,7 @@ func pathConfig(b *kubeAuthBackend) *framework.Path {
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Kubernetes CA Certificate",
 				},
+				Required: false,
 			},
 			"token_reviewer_jwt": {
 				Type: framework.TypeString,
@@ -141,10 +142,6 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 		}
 	}
 
-	if disableLocalJWT && caCert == "" {
-		return logical.ErrorResponse("kubernetes_ca_cert must be given when disable_local_ca_jwt is true"), nil
-	}
-
 	config := &kubeConfig{
 		PublicKeys:           make([]interface{}, len(pemList)),
 		PEMKeys:              pemList,
@@ -181,7 +178,7 @@ func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Requ
 
 		b.httpClient.Transport.(*http.Transport).TLSClientConfig = tlsConfig
 	}
-
+	
 	var err error
 	for i, pem := range pemList {
 		config.PublicKeys[i], err = parsePublicKeyPEM([]byte(pem))


### PR DESCRIPTION
# Overview
Some users didn't find it necessary for Vault to enforce the CA cert or PEM keys. Examples can be found in the related issues.

# Design of Change
We add false booleans to the `kubernetes_ca_cert` and` pem_keys` fields. While the `required`  field on the `FieldSchema` struct is deprecated we added this just for future reference and documentation. We also remove checks that enforced `kubernetes_ca_cert`  to be present instead we just default to the local CA cert if `kubernetes_ca_cert` is not set which will return an error of `x509: certificate signed by unknown authority` if the user did supply an appropriate CA cert. 

# Related Issues
[Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[Issue #88](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/88)

# Docs
I don't believe docs needed to be added since this is implied in the example below.

![Screen Shot 2022-04-21 at 4 11 55 PM](https://user-images.githubusercontent.com/46610773/164565907-0d8c12d4-ac60-43e6-ba77-a0005398feea.png)

