### PR TITLE
Add PATCH support for kubernetes/config

### DIFF
--- a/caching_file_reader_test.go
+++ b/caching_file_reader_test.go
@@ -27,7 +27,7 @@ func TestCachingFileReader(t *testing.T) {
 		})
 
 	// Write initial content to file and check that we can read it.
-	ioutil.WriteFile(f.Name(), []byte(content1), 0644)
+	ioutil.WriteFile(f.Name(), []byte(content1), 0o644)
 	got, err := r.ReadFile()
 	if err != nil {
 		t.Error(err)
@@ -37,7 +37,7 @@ func TestCachingFileReader(t *testing.T) {
 	}
 
 	// Write new content to the file.
-	ioutil.WriteFile(f.Name(), []byte(content2), 0644)
+	ioutil.WriteFile(f.Name(), []byte(content2), 0o644)
 
 	// Advance simulated time, but not enough for cache to expire.
 	currentTime = currentTime.Add(30 * time.Second)

--- a/path_config.go
+++ b/path_config.go
@@ -123,24 +123,25 @@ func (b *kubeAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reque
 
 // pathConfigWrite handles create and update commands to the config
 func (b *kubeAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	config := &kubeConfig{
-		DisableISSValidation: true,
-	}
-	return b.updateConfig(ctx, config, req, data)
+	return b.updateConfig(ctx, nil, req, data)
 }
 
 func (b *kubeAuthBackend) pathConfigPatch(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	config, err := b.config(ctx, req.Storage)
 	if err != nil {
 		return nil, err
-	} else if config == nil {
-		return logical.ErrorResponse("No config to update"), nil
 	}
 
 	return b.updateConfig(ctx, config, req, data)
 }
 
 func (b *kubeAuthBackend) updateConfig(ctx context.Context, config *kubeConfig, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	if config == nil {
+		config = &kubeConfig{
+			DisableISSValidation: true,
+		}
+	}
+
 	if v, ok := data.GetOk("kubernetes_host"); ok {
 		config.Host = v.(string)
 	}

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -550,7 +550,7 @@ func TestConfig_Patch(t *testing.T) {
 		finalConfig   *kubeConfig
 	}{
 		"missing-config": {
-			expectError: "No config to update",
+			expectError: "no host provided",
 		},
 		"update-disable_iss_validation": {
 			initialConfig: map[string]interface{}{


### PR DESCRIPTION
It can be usefull to be able to change the value of some parameters in
the config but not others.

For example when changing disable_iss_validation we needed to keep
token_reviewer_jwt as was already set, but since this value is not
returned by pathConfigRead() there is no way to do this if you do not
already do know what value it was set to.

This patch adds PATCH support to the kubernetes/config endpoint so that
any parameter can be updated while not changing the other ones.

