### PR TITLE
Add support for JWT signature algorithm ES384 (support removed since 1.13.0)

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -23,7 +23,7 @@ var defaultJWTIssuer = "kubernetes/serviceaccount"
 // See https://datatracker.ietf.org/doc/html/rfc7518#section-3.
 var supportedJwtAlgs = []capjwt.Alg{
 	capjwt.RS256, capjwt.RS384, capjwt.RS512,
-	capjwt.ES256, capjwt.RS384, capjwt.ES512,
+	capjwt.ES256, capjwt.ES384, capjwt.ES512,
 }
 
 // pathLogin returns the path configurations for login endpoints


### PR DESCRIPTION
# Overview
Add support for the previously supported JWT signing algorithm ES384. Support for this algorithm is likely removed accidentally in the change [switch from golang-jwt to cap+jose](https://github.com/hashicorp/vault-plugin-auth-kubernetes/commit/f706889f82e62f413c5465f59c4859a1ea8f6166#diff-e9cabdd28848f01142dd2db22533f3f7e7ffd87d064f2edbb7149f1b6d4bbecdL26).
![image](https://user-images.githubusercontent.com/5213151/187872810-cef8627a-259f-482b-83b7-985eb4adab2c.png)

Kubernetes supports [this algorithm](https://github.com/kubernetes/kubernetes/blob/v1.25.0/pkg/serviceaccount/jwt.go#L152), without it some Kubernetes clusters can't authenticate to Vault.

# Related Issues/Pull Requests
[Issue #159](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/159)
