### PR TITLE
Repo hygiene

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0
+          go-version: 1.19.1
       - uses: actions/cache@v2
         with:
           path: |
@@ -32,23 +32,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.21.10, 1.22.7, 1.23.6, 1.24.0]
+        kind-k8s-version: [1.22.13, 1.23.10, 1.24.4, 1.25.0]
     steps:
       - uses: actions/checkout@v2
       - name: Create K8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
-          version: v0.13.0
+          version: v0.14.0
           cluster_name: vault-plugin-auth-kubernetes
           config: integrationtest/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
       # Must come _after_ kind-action, because the kind step also sets up a kubectl binary.
       - uses: azure/setup-kubectl@v2.0
         with:
-          version: 'v1.24.0'
+          version: 'v1.25.0'
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0
+          go-version: 1.19.1
       - uses: actions/cache@v2
         with:
           path: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 KIND_CLUSTER_NAME?=vault-plugin-auth-kubernetes
 
 # kind k8s version
-KIND_K8S_VERSION?=v1.24.0
+KIND_K8S_VERSION?=v1.25.0
 
 .PHONY: default
 default: dev
@@ -52,7 +52,7 @@ vault-image:
 setup-integration-test: teardown-integration-test vault-image
 	kind --name ${KIND_CLUSTER_NAME} load docker-image hashicorp/vault:dev
 	kubectl create namespace test
-	helm install vault vault --repo https://helm.releases.hashicorp.com --version=0.19.0 \
+	helm install vault vault --repo https://helm.releases.hashicorp.com --version=0.22.0 \
 		--wait --timeout=5m \
 		--namespace=test \
 		--set server.dev.enabled=true \

--- a/caching_file_reader_test.go
+++ b/caching_file_reader_test.go
@@ -27,7 +27,7 @@ func TestCachingFileReader(t *testing.T) {
 		})
 
 	// Write initial content to file and check that we can read it.
-	ioutil.WriteFile(f.Name(), []byte(content1), 0644)
+	ioutil.WriteFile(f.Name(), []byte(content1), 0o644)
 	got, err := r.ReadFile()
 	if err != nil {
 		t.Error(err)
@@ -37,7 +37,7 @@ func TestCachingFileReader(t *testing.T) {
 	}
 
 	// Write new content to the file.
-	ioutil.WriteFile(f.Name(), []byte(content2), 0644)
+	ioutil.WriteFile(f.Name(), []byte(content2), 0o644)
 
 	// Advance simulated time, but not enough for cache to expire.
 	currentTime = currentTime.Add(30 * time.Second)

--- a/go.mod
+++ b/go.mod
@@ -59,9 +59,9 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect
-	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
+	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,9 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220906165146-f3363e06e74c h1:yKufUcDwucU5urd+50/Opbt4AYpqthk7wHpHok8f1lo=
+golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -525,9 +526,11 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -17,11 +17,12 @@ import (
 
 // Set the environment variable INTEGRATION_TESTS to any non-empty value to run
 // the tests in this package. The test assumes it has available:
-//   - kubectl
-//   - A Kubernetes cluster in which:
-//       - it can use the `test` namespace
-//       - Vault is deployed and accessible
-//       - There is a serviceaccount called test-token-reviewer-account with access to the TokenReview API
+// - kubectl
+// - A Kubernetes cluster in which:
+//   - it can use the `test` namespace
+//   - Vault is deployed and accessible
+//   - There is a serviceaccount called test-token-reviewer-account with access to the TokenReview API
+//
 // See `make setup-integration-test` for manual testing.
 func TestMain(m *testing.M) {
 	if os.Getenv("INTEGRATION_TESTS") != "" {

--- a/integrationtest/vault/Dockerfile
+++ b/integrationtest/vault/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/hashicorp/vault:1.10.0
+FROM docker.mirror.hashicorp.services/hashicorp/vault:1.11.3
 
 # Don't use `kubernetes` as plugin name to ensure we don't silently fall back to
 # the built-in kubernetes auth plugin if something goes wrong.

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -481,7 +481,7 @@ func TestConfig_LocalJWTRenewal(t *testing.T) {
 	token2 := "after-renewal"
 
 	// Write initial token to the temp file.
-	ioutil.WriteFile(f.Name(), []byte(token1), 0644)
+	ioutil.WriteFile(f.Name(), []byte(token1), 0o644)
 
 	data := map[string]interface{}{
 		"kubernetes_host": "host",
@@ -510,7 +510,7 @@ func TestConfig_LocalJWTRenewal(t *testing.T) {
 	}
 
 	// Write new value to the token file to simulate renewal.
-	ioutil.WriteFile(f.Name(), []byte(token2), 0644)
+	ioutil.WriteFile(f.Name(), []byte(token2), 0o644)
 
 	// Load again to check we still got the old cached token from memory.
 	conf, err = b.(*kubeAuthBackend).loadConfig(context.Background(), storage)

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/vault/sdk/helper/tokenutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -20,6 +19,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/helper/tokenutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
 	josejwt "gopkg.in/square/go-jose.v2/jwt"


### PR DESCRIPTION
Updated go to 1.19.1, testing k8s up to 1.25.0, vault-helm 0.22.0, Vault 1.11.3, and some system lib updates:

```
go get golang.org/x/net@v0.0.0-20220906165146-f3363e06e74c
go get golang.org/x/sys@v0.0.0-20220728004956-3c1f35247d10
go mod tidy
```