### PR TITLE
fix role update endpoint and provide patch method

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -228,31 +228,7 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 
 	// Handle upgrade cases
-	{
-		if err := tokenutil.UpgradeValue(data, "policies", "token_policies", &role.Policies, &role.TokenPolicies); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "bound_cidrs", "token_bound_cidrs", &role.BoundCIDRs, &role.TokenBoundCIDRs); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "num_uses", "token_num_uses", &role.NumUses, &role.TokenNumUses); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "ttl", "token_ttl", &role.TTL, &role.TokenTTL); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "max_ttl", "token_max_ttl", &role.MaxTTL, &role.TokenMaxTTL); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "period", "token_period", &role.Period, &role.TokenPeriod); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-	}
+	role.handleLegacyFieldDefinitions(data)
 
 	if err := role.validateTokenLifetimes(b); err != nil {
 		return err, nil
@@ -318,31 +294,7 @@ func (b *kubeAuthBackend) pathRolePatch(ctx context.Context, req *logical.Reques
 	}
 
 	// Handle upgrade cases
-	{
-		if err := tokenutil.UpgradeValue(data, "policies", "token_policies", &role.Policies, &role.TokenPolicies); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "bound_cidrs", "token_bound_cidrs", &role.BoundCIDRs, &role.TokenBoundCIDRs); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "num_uses", "token_num_uses", &role.NumUses, &role.TokenNumUses); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "ttl", "token_ttl", &role.TTL, &role.TokenTTL); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "max_ttl", "token_max_ttl", &role.MaxTTL, &role.TokenMaxTTL); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-
-		if err := tokenutil.UpgradeValue(data, "period", "token_period", &role.Period, &role.TokenPeriod); err != nil {
-			return logical.ErrorResponse(err.Error()), nil
-		}
-	}
+	role.handleLegacyFieldDefinitions(data)
 
 	if err := role.validateTokenLifetimes(b); err != nil {
 		return err, nil
@@ -404,6 +356,33 @@ func (b *kubeAuthBackend) pathRolePatch(ctx context.Context, req *logical.Reques
 	}
 
 	return resp, nil
+}
+
+func (role *roleStorageEntry) handleLegacyFieldDefinitions(data *framework.FieldData) *logical.Response {
+	if err := tokenutil.UpgradeValue(data, "policies", "token_policies", &role.Policies, &role.TokenPolicies); err != nil {
+		return logical.ErrorResponse(err.Error())
+	}
+
+	if err := tokenutil.UpgradeValue(data, "bound_cidrs", "token_bound_cidrs", &role.BoundCIDRs, &role.TokenBoundCIDRs); err != nil {
+		return logical.ErrorResponse(err.Error())
+	}
+
+	if err := tokenutil.UpgradeValue(data, "num_uses", "token_num_uses", &role.NumUses, &role.TokenNumUses); err != nil {
+		return logical.ErrorResponse(err.Error())
+	}
+
+	if err := tokenutil.UpgradeValue(data, "ttl", "token_ttl", &role.TTL, &role.TokenTTL); err != nil {
+		return logical.ErrorResponse(err.Error())
+	}
+
+	if err := tokenutil.UpgradeValue(data, "max_ttl", "token_max_ttl", &role.MaxTTL, &role.TokenMaxTTL); err != nil {
+		return logical.ErrorResponse(err.Error())
+	}
+
+	if err := tokenutil.UpgradeValue(data, "period", "token_period", &role.Period, &role.TokenPeriod); err != nil {
+		return logical.ErrorResponse(err.Error())
+	}
+	return nil
 }
 
 func (role *roleStorageEntry) validateTokenLifetimes(backend *kubeAuthBackend) *logical.Response {

--- a/path_role.go
+++ b/path_role.go
@@ -94,6 +94,7 @@ default: %q
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.CreateOperation: b.pathRoleCreateUpdate,
 				logical.UpdateOperation: b.pathRoleCreateUpdate,
+				logical.PatchOperation:  b.pathRolePatch,
 				logical.ReadOperation:   b.pathRoleRead,
 				logical.DeleteOperation: b.pathRoleDelete,
 			},
@@ -220,17 +221,96 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	b.l.Lock()
 	defer b.l.Unlock()
 
+	role := &roleStorageEntry{}
+
+	if err := role.ParseTokenFields(req, data); err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
+
+	// Handle upgrade cases
+	{
+		if err := tokenutil.UpgradeValue(data, "policies", "token_policies", &role.Policies, &role.TokenPolicies); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		if err := tokenutil.UpgradeValue(data, "bound_cidrs", "token_bound_cidrs", &role.BoundCIDRs, &role.TokenBoundCIDRs); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		if err := tokenutil.UpgradeValue(data, "num_uses", "token_num_uses", &role.NumUses, &role.TokenNumUses); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		if err := tokenutil.UpgradeValue(data, "ttl", "token_ttl", &role.TTL, &role.TokenTTL); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		if err := tokenutil.UpgradeValue(data, "max_ttl", "token_max_ttl", &role.MaxTTL, &role.TokenMaxTTL); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		if err := tokenutil.UpgradeValue(data, "period", "token_period", &role.Period, &role.TokenPeriod); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+	}
+
+	if err := role.validateTokenLifetimes(b); err != nil {
+		return err, nil
+	}
+
+	var resp *logical.Response
+	if role.TokenMaxTTL > b.System().MaxLeaseTTL() {
+		resp = &logical.Response{}
+		resp.AddWarning("max_ttl is greater than the system or backend mount's maximum TTL value; issued tokens' max TTL value will be truncated")
+	}
+
+	role.ServiceAccountNames = data.Get("bound_service_account_names").([]string)
+	role.ServiceAccountNamespaces = data.Get("bound_service_account_namespaces").([]string)
+
+	if err := role.validateServiceAccountMetadata(); err != nil {
+		return err, nil
+	}
+
+	role.Audience = data.Get("audience").(string)
+	role.AliasNameSource = data.Get("alias_name_source").(string)
+
+	if err := validateAliasNameSource(role.AliasNameSource); err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	// Store the entry.
+	entry, err := logical.StorageEntryJSON("role/"+strings.ToLower(roleName), role)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("failed to create storage entry for role %s", roleName)
+	}
+	if err = req.Storage.Put(ctx, entry); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// pathRolePatch patches an existing role with provided options
+func (b *kubeAuthBackend) pathRolePatch(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	roleName := data.Get("name").(string)
+	if roleName == "" {
+		return logical.ErrorResponse("missing role name"), nil
+	}
+
+	b.l.Lock()
+	defer b.l.Unlock()
+
 	// Check if the role already exists
 	role, err := b.role(ctx, req.Storage, roleName)
 	if err != nil {
 		return nil, err
 	}
 
-	// Create a new entry object if this is a CreateOperation
-	if role == nil && req.Operation == logical.CreateOperation {
-		role = &roleStorageEntry{}
-	} else if role == nil {
-		return nil, fmt.Errorf("role entry not found during update operation")
+	if role == nil {
+		return logical.ErrorResponse("Unable to fetch role entry to patch"), nil
 	}
 
 	if err := role.ParseTokenFields(req, data); err != nil {
@@ -264,15 +344,8 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 		}
 	}
 
-	if role.TokenPeriod > b.System().MaxLeaseTTL() {
-		return logical.ErrorResponse(fmt.Sprintf("token period of '%q' is greater than the backend's maximum lease TTL of '%q'", role.TokenPeriod.String(), b.System().MaxLeaseTTL().String())), nil
-	}
-
-	// Check that the TTL value provided is less than the MaxTTL.
-	// Sanitizing the TTL and MaxTTL is not required now and can be performed
-	// at credential issue time.
-	if role.TokenMaxTTL > time.Duration(0) && role.TokenTTL > role.TokenMaxTTL {
-		return logical.ErrorResponse("token ttl should not be greater than token max ttl"), nil
+	if err := role.validateTokenLifetimes(b); err != nil {
+		return err, nil
 	}
 
 	var resp *logical.Response
@@ -286,27 +359,15 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	} else if req.Operation == logical.CreateOperation {
 		role.ServiceAccountNames = data.Get("bound_service_account_names").([]string)
 	}
-	// Verify names was not empty
-	if len(role.ServiceAccountNames) == 0 {
-		return logical.ErrorResponse("%q can not be empty", "bound_service_account_names"), nil
-	}
-	// Verify * was not set with other data
-	if len(role.ServiceAccountNames) > 1 && strutil.StrListContains(role.ServiceAccountNames, "*") {
-		return logical.ErrorResponse("can not mix %q with values", "*"), nil
-	}
 
 	if namespaces, ok := data.GetOk("bound_service_account_namespaces"); ok {
 		role.ServiceAccountNamespaces = namespaces.([]string)
 	} else if req.Operation == logical.CreateOperation {
 		role.ServiceAccountNamespaces = data.Get("bound_service_account_namespaces").([]string)
 	}
-	// Verify namespaces is not empty
-	if len(role.ServiceAccountNamespaces) == 0 {
-		return logical.ErrorResponse("%q can not be empty", "bound_service_account_namespaces"), nil
-	}
-	// Verify * was not set with other data
-	if len(role.ServiceAccountNamespaces) > 1 && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
-		return logical.ErrorResponse("can not mix %q with values", "*"), nil
+
+	if err := role.validateServiceAccountMetadata(); err != nil {
+		return err, nil
 	}
 
 	// optional audience field
@@ -343,6 +404,45 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 
 	return resp, nil
+}
+
+func (role *roleStorageEntry) validateTokenLifetimes(backend *kubeAuthBackend) *logical.Response {
+	if role.TokenPeriod > backend.System().MaxLeaseTTL() {
+		return logical.ErrorResponse(
+			fmt.Sprintf(
+				"token period of '%q' is greater than the backend's maximum lease TTL of '%q'",
+				role.TokenPeriod.String(),
+				backend.System().MaxLeaseTTL().String(),
+			),
+		)
+	}
+
+	// Check that the TTL value provided is less than the MaxTTL.
+	// Sanitizing the TTL and MaxTTL is not required now and can be performed
+	// at credential issue time.
+	if role.TokenMaxTTL > time.Duration(0) && role.TokenTTL > role.TokenMaxTTL {
+		return logical.ErrorResponse("token ttl should not be greater than token max ttl")
+	}
+	return nil
+}
+
+func (role *roleStorageEntry) validateServiceAccountMetadata() *logical.Response {
+	if len(role.ServiceAccountNames) == 0 {
+		return logical.ErrorResponse("%q can not be empty", "bound_service_account_names")
+	}
+	// Verify * was not set with other data
+	if len(role.ServiceAccountNames) > 1 && strutil.StrListContains(role.ServiceAccountNames, "*") {
+		return logical.ErrorResponse("can not mix %q with values", "*")
+	}
+	// Verify namespaces is not empty
+	if len(role.ServiceAccountNamespaces) == 0 {
+		return logical.ErrorResponse("%q can not be empty", "bound_service_account_namespaces")
+	}
+	// Verify * was not set with other data
+	if len(role.ServiceAccountNamespaces) > 1 && strutil.StrListContains(role.ServiceAccountNamespaces, "*") {
+		return logical.ErrorResponse("can not mix %q with values", "*")
+	}
+	return nil
 }
 
 // roleStorageEntry stores all the options that are set on an role


### PR DESCRIPTION
# Overview

Fix the update endpoint for the role configuration to behave according to POST RESTful definitions. Add a PATCH endpoint for the role configuration.

This change might affect users that misuse the POST endpoints to update individual fields in the role configuration. If they omit required fields, this will now return an error, and if they simply omit fields, these will not be changed back to defaults (as opposed to keeping the value that was previously configured).

# Design of Change

I reused most of the code that used to be the update function for the patch method (as it actually behaved like a patch). Also refactored some code into own methods to reduce code duplication.

# Related Issues/Pull Requests

[ ] [Issue #163](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/163)
[ ] [Vault PR #17371](https://github.com/hashicorp/vault/pull/17371)

# Contributor Checklist

[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[] Backwards compatible
