### PR TITLE
Fix for CA certificate not reloading properly

### DIFF
--- a/path_config_test.go
+++ b/path_config_test.go
@@ -143,6 +143,27 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("got unexpected error: %v", resp.Error())
 	}
 
+	// test invalid ca
+	data = map[string]interface{}{
+		"kubernetes_ca_cert": "bad",
+		"kubernetes_host":    "host",
+	}
+
+	req = &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      configPath,
+		Storage:   storage,
+		Data:      data,
+	}
+
+	resp, _ = b.HandleRequest(context.Background(), req)
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error")
+	}
+	if resp.Error().Error() != "kubernetes_ca_cert contains an invalid CA certificate" {
+		t.Fatalf("got unexpected error: %v", resp.Error())
+	}
+
 	// Test success with no certs
 	data = map[string]interface{}{
 		"kubernetes_host":    "host",
@@ -536,6 +557,7 @@ func TestConfig_LocalJWTRenewal(t *testing.T) {
 	}
 }
 
+// Subject: C = US, ST = Washington, L = Seattle, O = Vault Testing Authority, CN = example.net
 var testLocalCACert string = `-----BEGIN CERTIFICATE-----
 MIIDVDCCAjwCCQDFiyFY1M6afTANBgkqhkiG9w0BAQsFADBsMQswCQYDVQQGEwJV
 UzETMBEGA1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEgMB4GA1UE
@@ -597,6 +619,7 @@ srxZG4EwDAYDVR0TBAUwAwEB/zAJBgcqhkjOPQQBA2gAMGUCMCR+CvAoNBhqSe2M
 GxqJpa7Onn15Hu8zTsdzeYBqUUXA6wtn+Pa7197CgUkfty9yc2eeQw==
 -----END CERTIFICATE-----`
 
+// Subject: CN = minikubeCA
 var testCACert string = `
 -----BEGIN CERTIFICATE-----
 MIIC5zCCAc+gAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwptaW5p

--- a/path_login.go
+++ b/path_login.go
@@ -115,6 +115,11 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, errors.New("could not load backend configuration")
 	}
 
+	err = b.updateHTTPClient(config)
+	if err != nil {
+		return nil, err
+	}
+
 	serviceAccount, err := b.parseAndValidateJWT(jwtStr, role, config)
 	if err != nil {
 		if err == jose.ErrCryptoFailure || strings.Contains(err.Error(), "verifying token signature") {


### PR DESCRIPTION
# Overview

This is a bug fix for two scenarios.

#142 introduces a cached HTTP client. The TLSConfig of the client is only set at 1) initialization time, and 2) 'config write'. If the CA configuration cannot be fetched at initialization time, then the TLSConfig remains empty for the life time of the Vault process, unless the user does manual actions (e.g. seal/unseal, config write).

Similarly, there is a use case where CA can be read directly from disk. If the CA changes, the TLSConfig is not updated properly.

# Design of Change
The HTTP client cert pool is updated before each request towards Kubernetes API Server is made. HTTP connections that exist (are alive, according to KeepAlive) will remain and work. New cert pool is taken into use when a if/new HTTP connections are established.

I found it difficult to add a test case for the scenario in #169. I have a test case for the scenario in #170. Do you think this is enough? I have manually tested the #169 scenario and it works.

A bonus change for free: before we write the config to backend, we try to add the CA certificate to a cert pool. If the certificate is invalid, then an error is produced. This basically fixes https://github.com/hashicorp/vault/issues/17315. Let me know if you want this as a separate PR. The reason why I made this change here is that we also check the return code of certPool.AppendCertsFromPEM() in updateHTTPClient(), so we should in config write as well.

# Related Issues/Pull Requests
#169 
#170 

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository (**=> bug fix without doc change**)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
