### PR TITLE
Update audience handling for correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Changes
 
+* Return HTTP 403 error code instead of 500 when JWT validation fails due to invalid issuer, audiences, or signing algorithm [GH-179](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/179)
+* Checks the Kubernetes API is audience-aware by checking for at least one compatible audience in the response from TokenReviews [GH-179](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/179)
 * Update to Go 1.19 [GH-166](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/166)
 * Update dependencies [GH-166](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/166):
 |             MODULE              |              VERSION               | NEW VERSION | DIRECT | VALID TIMESTAMPS |

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -77,7 +76,7 @@ func runCmd(command string) string {
 	return out.String()
 }
 
-func setupKubernetesAuth(t *testing.T, boundServiceAccountName string, kubeConfigOverride map[string]interface{}) (*api.Client, func()) {
+func setupKubernetesAuth(t *testing.T, boundServiceAccountName string, mountConfigOverride map[string]interface{}, roleConfigOverride map[string]interface{}) (*api.Client, func()) {
 	t.Helper()
 	// Pick up VAULT_ADDR and VAULT_TOKEN from env vars
 	client, err := api.NewClient(nil)
@@ -92,7 +91,7 @@ func setupKubernetesAuth(t *testing.T, boundServiceAccountName string, kubeConfi
 		t.Fatal(err)
 	}
 
-	deferred := func() {
+	cleanup := func() {
 		_, err = client.Logical().Delete("sys/auth/kubernetes")
 		if err != nil {
 			t.Fatal(err)
@@ -100,40 +99,46 @@ func setupKubernetesAuth(t *testing.T, boundServiceAccountName string, kubeConfi
 	}
 
 	defer func() {
-		// just in case setupKubernetesAuth panics before returning deferred to the caller
+		// just in case setupKubernetesAuth panics before returning cleanup to the caller
 		if panicErr := recover(); panicErr != nil {
-			deferred()
+			cleanup()
 			panic(panicErr)
 		} else if t.Failed() {
-			deferred()
+			cleanup()
 		}
 	}()
 
-	if len(kubeConfigOverride) == 0 {
-		_, err = client.Logical().Write("auth/kubernetes/config", map[string]interface{}{
-			"kubernetes_host": "https://kubernetes.default.svc.cluster.local",
-		})
-	} else {
-		_, err = client.Logical().Write("auth/kubernetes/config", kubeConfigOverride)
+	mountConfig := map[string]interface{}{
+		"kubernetes_host": "https://kubernetes.default.svc.cluster.local",
 	}
+	if len(mountConfigOverride) != 0 {
+		mountConfig = mountConfigOverride
+	}
+
+	_, err = client.Logical().Write("auth/kubernetes/config", mountConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = client.Logical().Write("auth/kubernetes/role/test-role", map[string]interface{}{
+	roleConfig := map[string]interface{}{
 		"bound_service_account_names":      boundServiceAccountName,
 		"bound_service_account_namespaces": "test",
-	})
+	}
+	if len(roleConfigOverride) != 0 {
+		roleConfig = roleConfigOverride
+	}
+
+	_, err = client.Logical().Write("auth/kubernetes/role/test-role", roleConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return client, deferred
+	return client, cleanup
 }
 
 func TestSuccess(t *testing.T) {
-	client, deferred := setupKubernetesAuth(t, "vault", nil)
-	defer deferred()
+	client, cleanup := setupKubernetesAuth(t, "vault", nil, nil)
+	defer cleanup()
 
 	_, err := client.Logical().Write("auth/kubernetes/login", map[string]interface{}{
 		"role": "test-role",
@@ -145,11 +150,11 @@ func TestSuccess(t *testing.T) {
 }
 
 func TestSuccessWithTokenReviewerJwt(t *testing.T) {
-	client, deferred := setupKubernetesAuth(t, "vault", map[string]interface{}{
+	client, cleanup := setupKubernetesAuth(t, "vault", map[string]interface{}{
 		"kubernetes_host":    "https://kubernetes.default.svc.cluster.local",
 		"token_reviewer_jwt": os.Getenv("TOKEN_REVIEWER_JWT"),
-	})
-	defer deferred()
+	}, nil)
+	defer cleanup()
 
 	_, err := client.Logical().Write("auth/kubernetes/login", map[string]interface{}{
 		"role": "test-role",
@@ -161,11 +166,11 @@ func TestSuccessWithTokenReviewerJwt(t *testing.T) {
 }
 
 func TestFailWithBadTokenReviewerJwt(t *testing.T) {
-	client, deferred := setupKubernetesAuth(t, "vault", map[string]interface{}{
+	client, cleanup := setupKubernetesAuth(t, "vault", map[string]interface{}{
 		"kubernetes_host":    "https://kubernetes.default.svc.cluster.local",
 		"token_reviewer_jwt": badTokenReviewerJwt,
-	})
-	defer deferred()
+	}, nil)
+	defer cleanup()
 
 	_, err := client.Logical().Write("auth/kubernetes/login", map[string]interface{}{
 		"role": "test-role",
@@ -173,7 +178,7 @@ func TestFailWithBadTokenReviewerJwt(t *testing.T) {
 	})
 	respErr, ok := err.(*api.ResponseError)
 	if !ok {
-		t.Fatalf("Expected api.ResponseError but was: %s", reflect.TypeOf(err).Name())
+		t.Fatalf("Expected api.ResponseError but was: %T", err)
 	}
 	if respErr.StatusCode != http.StatusForbidden {
 		t.Fatalf("Expected 403 but was %d: %s", respErr.StatusCode, respErr.Error())
@@ -181,8 +186,8 @@ func TestFailWithBadTokenReviewerJwt(t *testing.T) {
 }
 
 func TestUnauthorizedServiceAccountErrorCode(t *testing.T) {
-	client, deferred := setupKubernetesAuth(t, "badServiceAccount", nil)
-	defer deferred()
+	client, cleanup := setupKubernetesAuth(t, "badServiceAccount", nil, nil)
+	defer cleanup()
 
 	_, err := client.Logical().Write("auth/kubernetes/login", map[string]interface{}{
 		"role": "test-role",
@@ -190,7 +195,7 @@ func TestUnauthorizedServiceAccountErrorCode(t *testing.T) {
 	})
 	respErr, ok := err.(*api.ResponseError)
 	if !ok {
-		t.Fatalf("Expected api.ResponseError but was: %s", reflect.TypeOf(err).Name())
+		t.Fatalf("Expected api.ResponseError but was: %T", err)
 	}
 	if respErr.StatusCode != http.StatusForbidden {
 		t.Fatalf("Expected 403 but was %d: %s", respErr.StatusCode, respErr.Error())
@@ -198,3 +203,59 @@ func TestUnauthorizedServiceAccountErrorCode(t *testing.T) {
 }
 
 var badTokenReviewerJwt = "eyJhbGciOiJSUzI1NiIsImtpZCI6IkZza1ViNWREek8tQ05uaVk3TU5mRWZ2dEx5bzFuU0tsV3JhUU5nekhVQ28ifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNjgwODg5NjQ4LCJpYXQiOjE2NDkzNTM2NDgsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJ0ZXN0IiwicG9kIjp7Im5hbWUiOiJ2YXVsdC0wIiwidWlkIjoiYTQwNGZiMTktNWQ4MC00OTBlLTkwYjktMGJjNWE3NzA5ODdkIn0sInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJ2YXVsdCIsInVpZCI6ImI2ZTM2ZDMxLTA2MDQtNDE5MS04Y2JjLTAwYzg4ZWViZDlmOSJ9LCJ3YXJuYWZ0ZXIiOjE2NDkzNTcyNTV9LCJuYmYiOjE2NDkzNTM2NDgsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDp0ZXN0OnZhdWx0In0.hxzMpKx38rKvaWUBNEg49TioRXt_JT1Z5st4A9NeBWO2xiC8hCDgVJRWqPzejz-sYoQGhZyZcrTa0cbNRIevcR7XH4DnHd27OOzSoj198I2DAdLfw_pntzOjq35-tZhxSYXsfKH69DSpHACpu5HHUAf1aiY3B6cq5Z3gXbtaoHBocfNwvtOirGL8pTYXo1kNCkcahDPfpf3faztyUQ77v0viBKIAqwxDuGks4crqIG5jT_tOnXbb7PahwtE5cS3bMLjQb1j5oEcgq6HF4NMV46Ly479QRoXtYWWsI9OSwl4H7G9Rel3fr9q4IMdCCI5A-FLxL2Fpep9TDwrNQ3mhBQ"
+
+func TestAudienceValidation(t *testing.T) {
+	jwtWithDefaultAud := runCmd("kubectl --namespace=test create token vault")
+	jwtWithAudA := runCmd("kubectl --namespace=test --audience=a create token vault")
+	jwtWithAudB := runCmd("kubectl --namespace=test --audience=b create token vault")
+
+	for name, tc := range map[string]struct {
+		audienceConfig string
+		jwt            string
+		expectSuccess  bool
+	}{
+		"config: default, JWT: default": {"https://kubernetes.default.svc.cluster.local", jwtWithDefaultAud, true},
+		"config: default, JWT: a":       {"https://kubernetes.default.svc.cluster.local", jwtWithAudA, false},
+		"config: a, JWT: a":             {"a", jwtWithAudA, true},
+		"config: a, JWT: b":             {"a", jwtWithAudB, false},
+		"config: unset, JWT: default":   {"", jwtWithDefaultAud, true},
+		"config: unset, JWT: a":         {"", jwtWithAudA, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			roleConfig := map[string]interface{}{
+				"bound_service_account_names":      "vault",
+				"bound_service_account_namespaces": "test",
+			}
+			if tc.audienceConfig != "" {
+				roleConfig["audience"] = tc.audienceConfig
+			}
+			client, cleanup := setupKubernetesAuth(t, "vault", nil, roleConfig)
+			defer cleanup()
+
+			login := func(jwt string) error {
+				_, err := client.Logical().Write("auth/kubernetes/login", map[string]interface{}{
+					"role": "test-role",
+					"jwt":  jwt,
+				})
+				return err
+			}
+
+			err := login(tc.jwt)
+			if err != nil {
+				if tc.expectSuccess {
+					t.Fatal("Expected successful login", err)
+				} else {
+					respErr, ok := err.(*api.ResponseError)
+					if !ok {
+						t.Fatalf("Expected api.ResponseError but was: %T", err)
+					}
+					if respErr.StatusCode != http.StatusForbidden {
+						t.Fatalf("Expected 403 but was %d: %s", respErr.StatusCode, respErr.Error())
+					}
+				}
+			} else if !tc.expectSuccess {
+				t.Fatal("Expected error but successfully logged in")
+			}
+		})
+	}
+}


### PR DESCRIPTION
I took a deeper look at our audience validation logic in response to #175, and saw a few things that could be improved, using the [TokenReview API docs](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) as a reference. I still don't think the logic is 100% correct when populating the TokenReview request audiences, but I think we have made some slightly incompatible promises in the Vault API, so I'm hesitant to align completely with the intended usage.

* Return 403 instead of 500 when audience validation fails
* Pass our expected audience instead of the token's audience to TokenReview
* Validate the TokenReview server is audience-aware by checking the returned audiences