### PR TITLE
chore: add missing error checks

### DIFF
--- a/caching_file_reader_test.go
+++ b/caching_file_reader_test.go
@@ -30,7 +30,10 @@ func TestCachingFileReader(t *testing.T) {
 		})
 
 	// Write initial content to file and check that we can read it.
-	ioutil.WriteFile(f.Name(), []byte(content1), 0o644)
+	err = ioutil.WriteFile(f.Name(), []byte(content1), 0o644)
+	if err != nil {
+		t.Error(err)
+	}
 	got, err := r.ReadFile()
 	if err != nil {
 		t.Error(err)
@@ -40,7 +43,10 @@ func TestCachingFileReader(t *testing.T) {
 	}
 
 	// Write new content to the file.
-	ioutil.WriteFile(f.Name(), []byte(content2), 0o644)
+	err = ioutil.WriteFile(f.Name(), []byte(content2), 0o644)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Advance simulated time, but not enough for cache to expire.
 	currentTime = currentTime.Add(30 * time.Second)

--- a/cmd/vault-plugin-auth-kubernetes/main.go
+++ b/cmd/vault-plugin-auth-kubernetes/main.go
@@ -15,8 +15,11 @@ import (
 
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
+
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
@@ -28,7 +31,11 @@ func main() {
 		TLSProviderFunc: tlsProviderFunc,
 	})
 	if err != nil {
-		log.L().Error("plugin shutting down", "error", err)
-		os.Exit(1)
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	log.L().Error("plugin shutting down", "error", err)
+	os.Exit(1)
 }

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -20,14 +20,20 @@ func setupLocalFiles(t *testing.T, b logical.Backend) func() {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cert.WriteString(testLocalCACert)
+	_, err = cert.WriteString(testLocalCACert)
+	if err != nil {
+		t.Fatal(err)
+	}
 	cert.Close()
 
 	token, err := ioutil.TempFile("", "token")
 	if err != nil {
 		t.Fatal(err)
 	}
-	token.WriteString(testLocalJWT)
+	_, err = token.WriteString(testLocalJWT)
+	if err != nil {
+		t.Fatal(err)
+	}
 	token.Close()
 	b.(*kubeAuthBackend).localCACertReader = newCachingFileReader(cert.Name(), caReloadPeriod, time.Now)
 	b.(*kubeAuthBackend).localSATokenReader = newCachingFileReader(token.Name(), jwtReloadPeriod, time.Now)
@@ -484,7 +490,10 @@ func TestConfig_LocalJWTRenewal(t *testing.T) {
 	token2 := "after-renewal"
 
 	// Write initial token to the temp file.
-	ioutil.WriteFile(f.Name(), []byte(token1), 0o644)
+	err = ioutil.WriteFile(f.Name(), []byte(token1), 0o644)
+	if err != nil {
+		t.Error(err)
+	}
 
 	data := map[string]interface{}{
 		"kubernetes_host": "host",
@@ -513,7 +522,10 @@ func TestConfig_LocalJWTRenewal(t *testing.T) {
 	}
 
 	// Write new value to the token file to simulate renewal.
-	ioutil.WriteFile(f.Name(), []byte(token2), 0o644)
+	err = ioutil.WriteFile(f.Name(), []byte(token2), 0o644)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Load again to check we still got the old cached token from memory.
 	conf, err = b.(*kubeAuthBackend).loadConfig(context.Background(), storage)


### PR DESCRIPTION
# Overview

- Add missing error check to main for parsing CLI flags.
- Add missing error checks to tests for I/O related calls.

If `flag.Parse()` fails now the error is hidden from the user. Adding the missing checks to tests just improve code quality.

# Design of Change

Noticed an issue with CLI flag parsing. Fixed it first. Checked with [`errcheck` linter](https://github.com/kisielk/errcheck) if the codebase has other missing error checks.

# Related Issues/Pull Requests

None

# Contributor Checklist

[-] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet

None needed

[-] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)

None needed

[x] Backwards compatible
