### PR TITLE
indicate that token reviewer jwt is set on config read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Improvements
 
 * Support bound service account namespace selector [GH-218](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/218)
+* Indicate that token reviewer jwt is set on config read [GH-221](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/221)
 
 ## 0.17.1 (Sept 7, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Improvements
 
 * Support bound service account namespace selector [GH-218](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/218)
-* Indicate that token reviewer jwt is set on config read [GH-221](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/221)
+* Indicate that token reviewer JWT is set on config read [GH-221](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/221)
 
 ## 0.17.1 (Sept 7, 2023)
 

--- a/path_config.go
+++ b/path_config.go
@@ -119,6 +119,11 @@ func (b *kubeAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reque
 	} else if config == nil {
 		return nil, nil
 	} else {
+		var tokenReviewerJWTSet bool
+		if config.TokenReviewerJWT != "" {
+			tokenReviewerJWTSet = true
+		}
+
 		// Create a map of data to be returned
 		resp := &logical.Response{
 			Data: map[string]interface{}{
@@ -128,6 +133,7 @@ func (b *kubeAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reque
 				"issuer":                 config.Issuer,
 				"disable_iss_validation": config.DisableISSValidation,
 				"disable_local_ca_jwt":   config.DisableLocalCAJwt,
+				"token_reviewer_jwt_set": tokenReviewerJWTSet,
 			},
 		}
 

--- a/path_config.go
+++ b/path_config.go
@@ -133,7 +133,7 @@ func (b *kubeAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reque
 				"issuer":                 config.Issuer,
 				"disable_iss_validation": config.DisableISSValidation,
 				"disable_local_ca_jwt":   config.DisableLocalCAJwt,
-				"token_reviewer_jwt_set": tokenReviewerJWTSet,
+				"token_reviewer_jwt_set": config.TokenReviewerJWT != "",
 			},
 		}
 

--- a/path_config.go
+++ b/path_config.go
@@ -119,11 +119,6 @@ func (b *kubeAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reque
 	} else if config == nil {
 		return nil, nil
 	} else {
-		var tokenReviewerJWTSet bool
-		if config.TokenReviewerJWT != "" {
-			tokenReviewerJWTSet = true
-		}
-
 		// Create a map of data to be returned
 		resp := &logical.Response{
 			Data: map[string]interface{}{

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -44,25 +44,20 @@ func setupLocalFiles(t *testing.T, b logical.Backend) func() {
 }
 
 func TestConfig_Read(t *testing.T) {
-	type args struct {
-		data map[string]interface{}
-	}
 	tests := []struct {
 		name string
-		args args
+		data map[string]interface{}
 		want map[string]interface{}
 	}{
 		{
 			name: "token-review-jwt-is-unset",
-			args: args{
-				data: map[string]interface{}{
-					"pem_keys":               []string{testRSACert, testECCert},
-					"kubernetes_host":        "host",
-					"kubernetes_ca_cert":     testCACert,
-					"issuer":                 "",
-					"disable_iss_validation": false,
-					"disable_local_ca_jwt":   false,
-				},
+			data: map[string]interface{}{
+				"pem_keys":               []string{testRSACert, testECCert},
+				"kubernetes_host":        "host",
+				"kubernetes_ca_cert":     testCACert,
+				"issuer":                 "",
+				"disable_iss_validation": false,
+				"disable_local_ca_jwt":   false,
 			},
 			want: map[string]interface{}{
 				"pem_keys":               []string{testRSACert, testECCert},
@@ -76,16 +71,14 @@ func TestConfig_Read(t *testing.T) {
 		},
 		{
 			name: "token-review-jwt-is-set",
-			args: args{
-				data: map[string]interface{}{
-					"pem_keys":               []string{testRSACert, testECCert},
-					"kubernetes_host":        "host",
-					"kubernetes_ca_cert":     testCACert,
-					"issuer":                 "",
-					"disable_iss_validation": false,
-					"disable_local_ca_jwt":   false,
-					"token_reviewer_jwt":     "test-token-review-jwt",
-				},
+			data: map[string]interface{}{
+				"pem_keys":               []string{testRSACert, testECCert},
+				"kubernetes_host":        "host",
+				"kubernetes_ca_cert":     testCACert,
+				"issuer":                 "",
+				"disable_iss_validation": false,
+				"disable_local_ca_jwt":   false,
+				"token_reviewer_jwt":     "test-token-review-jwt",
 			},
 			want: map[string]interface{}{
 				"pem_keys":               []string{testRSACert, testECCert},
@@ -100,36 +93,39 @@ func TestConfig_Read(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		b, storage := getBackend(t)
-		cleanup := setupLocalFiles(t, b)
-		defer cleanup()
-		req := &logical.Request{
-			Operation: logical.UpdateOperation,
-			Path:      configPath,
-			Storage:   storage,
-			Data:      tc.args.data,
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			b, storage := getBackend(t)
+			cleanup := setupLocalFiles(t, b)
+			t.Cleanup(cleanup)
 
-		resp, err := b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+			req := &logical.Request{
+				Operation: logical.UpdateOperation,
+				Path:      configPath,
+				Storage:   storage,
+				Data:      tc.data,
+			}
 
-		req = &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      configPath,
-			Storage:   storage,
-			Data:      nil,
-		}
+			resp, err := b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
 
-		resp, err = b.HandleRequest(context.Background(), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
+			req = &logical.Request{
+				Operation: logical.ReadOperation,
+				Path:      configPath,
+				Storage:   storage,
+				Data:      nil,
+			}
 
-		if !reflect.DeepEqual(resp.Data, tc.want) {
-			t.Fatalf("Expected did not equal actual: expected %#v\n got %#v\n", tc.want, resp.Data)
-		}
+			resp, err = b.HandleRequest(context.Background(), req)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("err:%s resp:%#v\n", err, resp)
+			}
+
+			if !reflect.DeepEqual(resp.Data, tc.want) {
+				t.Fatalf("Expected did not equal actual: expected %#v\n got %#v\n", tc.want, resp.Data)
+			}
+		})
 	}
 }
 

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -123,7 +123,7 @@ func TestConfig_Read(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(resp.Data, tc.want) {
-				t.Fatalf("Expected did not equal actual: expected %#v\n got %#v\n", tc.want, resp.Data)
+				t.Fatalf("expected %#v, got %#v", tc.want, resp.Data)
 			}
 		})
 	}

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -109,7 +109,7 @@ func TestConfig_Read(t *testing.T) {
 			if err != nil || (resp != nil && resp.IsError()) {
 				t.Fatalf("got unexpected error %s for resp %#v", err, resp)
 			}
-			
+
 			req = &logical.Request{
 				Operation: logical.ReadOperation,
 				Path:      configPath,

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -107,9 +107,9 @@ func TestConfig_Read(t *testing.T) {
 
 			resp, err := b.HandleRequest(context.Background(), req)
 			if err != nil || (resp != nil && resp.IsError()) {
-				t.Fatalf("err:%s resp:%#v\n", err, resp)
+				t.Fatalf("got unexpected error %s for resp %#v", err, resp)
 			}
-
+			
 			req = &logical.Request{
 				Operation: logical.ReadOperation,
 				Path:      configPath,

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -119,7 +119,7 @@ func TestConfig_Read(t *testing.T) {
 
 			resp, err = b.HandleRequest(context.Background(), req)
 			if err != nil || (resp != nil && resp.IsError()) {
-				t.Fatalf("err:%s resp:%#v\n", err, resp)
+				t.Fatalf("got unexpected error %s for resp %#v", err, resp)
 			}
 
 			if !reflect.DeepEqual(resp.Data, tc.want) {


### PR DESCRIPTION
# Overview
The read config endpoint does not expose the token_reviewer_jwt field for security reasons. Indication if it is set or not can save users from the kubernetes login route to verify.

# Design of Change
Add a key value pair to the response data on config read to indicate that the token reviewer jwt is set.

# Related Issues/Pull Requests
[ ] [Issue #68](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/68)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](https://github.com/hashicorp/vault/pull/24564)

[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
```
~/go/src/github.com/hashicorp/vault-plugin-auth-kubernetes (VAULT-1664-indicate-token-reviewer-jwt-set) $ make integration-test
cd integrationtest && INTEGRATION_TESTS=true CGO_ENABLED=0 KUBE_CONTEXT="kind-vault-plugin-auth-kubernetes" go test '-test.v' -count=1 -timeout=20m ./...
?   	github.com/hashicorp/vault-plugin-auth-kubernetes/integrationtest/k8s	[no test files]
=== RUN   TestSuccess
--- PASS: TestSuccess (0.14s)
=== RUN   TestSuccessWithTokenReviewerJwt
--- PASS: TestSuccessWithTokenReviewerJwt (0.09s)
=== RUN   TestSuccessWithNamespaceLabels
--- PASS: TestSuccessWithNamespaceLabels (0.09s)
=== RUN   TestFailWithMismatchNamespaceLabels
--- PASS: TestFailWithMismatchNamespaceLabels (0.09s)
=== RUN   TestFailWithBadTokenReviewerJwt
--- PASS: TestFailWithBadTokenReviewerJwt (0.08s)
=== RUN   TestUnauthorizedServiceAccountErrorCode
--- PASS: TestUnauthorizedServiceAccountErrorCode (0.08s)
=== RUN   TestAudienceValidation
=== RUN   TestAudienceValidation/config:_a,_JWT:_b
=== RUN   TestAudienceValidation/config:_unset,_JWT:_default
=== RUN   TestAudienceValidation/config:_unset,_JWT:_a
=== RUN   TestAudienceValidation/config:_default,_JWT:_default
=== RUN   TestAudienceValidation/config:_default,_JWT:_a
=== RUN   TestAudienceValidation/config:_a,_JWT:_a
--- PASS: TestAudienceValidation (0.46s)
    --- PASS: TestAudienceValidation/config:_a,_JWT:_b (0.07s)
    --- PASS: TestAudienceValidation/config:_unset,_JWT:_default (0.08s)
    --- PASS: TestAudienceValidation/config:_unset,_JWT:_a (0.08s)
    --- PASS: TestAudienceValidation/config:_default,_JWT:_default (0.08s)
    --- PASS: TestAudienceValidation/config:_default,_JWT:_a (0.07s)
    --- PASS: TestAudienceValidation/config:_a,_JWT:_a (0.08s)
PASS
ok  	github.com/hashicorp/vault-plugin-auth-kubernetes/integrationtest	2.180s
```
[ ] Backwards compatible
