### PR TITLE
Remove side effect of default JWT usage.

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -328,7 +328,7 @@ func (b *kubeAuthBackend) parseAndValidateJWT(ctx context.Context, client *http.
 		if config.Issuer != "" {
 			expected.Issuer = config.Issuer
 		} else {
-			config.Issuer = defaultJWTIssuer
+			expected.Issuer = defaultJWTIssuer
 		}
 	}
 


### PR DESCRIPTION
# Overview
I think this code is wrong. As written, it modifies the config object instead of assigning the default issuer to the `expected` struct. I believe it means the first JWT validation in the lifespan of the process will fail, but subsequent validations will work.

# Contributor Checklist
[X] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
This bug fix should be nearly invisible to the user.
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[X] Backwards compatible
