### PR TITLE
add role to alias metadata

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -205,6 +205,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 	metadata[metadataKeySAName] = sa.name()
 	metadata[metadataKeySANamespace] = sa.namespace()
 	metadata[metadataKeySASecretName] = sa.SecretName
+	metadata["role"] = roleName
 
 	auth := &logical.Auth{
 		Alias: &logical.Alias{

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -885,6 +885,18 @@ func TestLoginEntityAliasMetadataAssignment(t *testing.T) {
 			t.Fatalf("expected value %q got %q for key %q", expV, v, expK)
 		}
 	}
+
+	expK := "role"
+	expV := data["role"]
+	v, ok := resp.Auth.Alias.Metadata["role"]
+
+	if !ok {
+		t.Fatalf("expected key %q not found", expK)
+	}
+
+	if v != expV {
+		t.Fatalf("expected value %q got %q for key %q", expV, v, expK)
+	}
 }
 
 func TestAliasLookAhead(t *testing.T) {


### PR DESCRIPTION
# Overview
An implementation to include the role as entity alias metadata

# Design of Change
adding the already available role to the metadata map. 
I am not sure, if this backwards-compatible, if there was already some metadata with that key "role"

# Related Issues/Pull Requests
[X] [Issue #111](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/111)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
