### PR TITLE
Log Warning When Kubernetes Role Does not Have an Audience

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -353,8 +353,8 @@ func (b *kubeAuthBackend) parseAndValidateJWT(ctx context.Context, client *http.
 	// Roles will need to specify an audience in Vault v1.21+.
 	// Log a warning if the role does not specify one.
 	if strings.TrimSpace(role.Audience) == "" {
-		b.Logger().Warn(fmt.Sprintf("Role %s was used to authenticate into Vault. It does not have an audience specified. "+
-			"Vault v1.21+ will require an audience to be specified in the role to authenticate successfully.", roleName))
+		b.Logger().Warn("A role without an audience was used to authenticate into Vault."+
+			"Vault v1.21+ will require roles to have an audience.", "role_name", roleName)
 	} else {
 		expected.Audiences = []string{role.Audience}
 	}

--- a/path_role.go
+++ b/path_role.go
@@ -351,8 +351,8 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 			resp = &logical.Response{}
 		}
 
-		b.Logger().Warn(fmt.Sprintf("Role '%s' does not specify an audience. In Vault v1.21+, specifying an audience will be required.", roleName))
-		resp.AddWarning(fmt.Sprintf("Role '%s' does not specify an audience. In Vault v1.21+, specifying an audience will be required.", roleName))
+		b.Logger().Warn("This role does not have an audience. In Vault v1.21+, specifying an audience on roles will be required.", "role_name", roleName)
+		resp.AddWarning(fmt.Sprintf("Role %s does not have an audience. In Vault v1.21+, specifying an audience on roles will be required.", roleName))
 	}
 
 	if source, ok := data.GetOk("alias_name_source"); ok {


### PR DESCRIPTION
# Overview
Currently, Vault's Kubernetes authentication method does not require roles to specify an audience. As a result, an attacker could potentially craft a malicious JWT from a compromised or rogue Kubernetes cluster and use it to authenticate against Vault, especially if the associated cluster does not validate the `aud` claim. 

This pull request introduces a warning log when a role does not have an audience at the point of role creation/update and at the point of authentication. This change will be followed by a change for Vault 1.21+ that won't allow authentication into Vault when a role does not have an audience. Also, an error will be sent to the user when a role does not have an audience during role creation/update instead of a warning.

### Manual Testing
* Set up Kind cluster and Vault dev server
* Configured Kubernetes authentication and created role
* Verified that configuring a role without an audience prints out a warning

```
vault write auth/kubernetes/config \      
    token_reviewer_jwt="$(cat vault-sa-token)" \
    kubernetes_host="$KUBE_HOST" \
    kubernetes_ca_cert=@ca.crt

vault write auth/kubernetes/role/my-role \
    bound_service_account_names=my-app \
    bound_service_account_namespaces=default \
    policies=my-policy \
    ttl=24h
WARNING! The following warnings were returned from Vault:

  * This role does not specify an audience. In Vault v1.21+, specifying an
  audience will be required.
```

* Verified that the warning log appears when attempting to authenticate with a role that does not have an audience

```
2025-06-16T01:06:26.973-0700 [WARN]  auth.kubernetes.auth_kubernetes_34df32de.kubernetes.kubernetes: This role does not currently specify an audience. In Vault v1.21+, specifying an audience will be required to authenticate successfully.: timestamp=2025-06-16T01:06:26.973-0700
```