### PR TITLE
Backport Log Warning When Kubernetes Role Does not Have an Audience (#301)

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -290,8 +290,13 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 
 	var resp *logical.Response
+
+	// Warn if max_ttl is greater than system or backend mount's maximum TTL
 	if role.TokenMaxTTL > b.System().MaxLeaseTTL() {
-		resp = &logical.Response{}
+		if resp == nil {
+			resp = &logical.Response{}
+		}
+
 		resp.AddWarning("max_ttl is greater than the system or backend mount's maximum TTL value; issued tokens' max TTL value will be truncated")
 	}
 
@@ -334,9 +339,20 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
-	// optional audience field
+	// audiences will be required in kubernetes roles in a future Vault version
 	if audience, ok := data.GetOk("audience"); ok {
 		role.Audience = audience.(string)
+	}
+
+	// Vault 1.21+ will require an audience to be set on a role for security reasons.
+	// Log a warning if the role does not specify an audience.
+	if strings.TrimSpace(role.Audience) == "" {
+		if resp == nil {
+			resp = &logical.Response{}
+		}
+
+		b.Logger().Warn("This role does not have an audience. In Vault v1.21+, specifying an audience on roles will be required.", "role_name", roleName)
+		resp.AddWarning(fmt.Sprintf("Role %s does not have an audience. In Vault v1.21+, specifying an audience on roles will be required.", roleName))
 	}
 
 	if source, ok := data.GetOk("alias_name_source"); ok {


### PR DESCRIPTION
Backport of [GH-301](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/301) to Vault 1.20.