### PR TITLE
Backport of Audience Spacing Fix to 1.18.x

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -353,7 +353,7 @@ func (b *kubeAuthBackend) parseAndValidateJWT(ctx context.Context, client *http.
 	// Roles will need to specify an audience in Vault v1.21+.
 	// Log a warning if the role does not specify one.
 	if strings.TrimSpace(role.Audience) == "" {
-		b.Logger().Warn("A role without an audience was used to authenticate into Vault."+
+		b.Logger().Warn("A role without an audience was used to authenticate into Vault. "+
 			"Vault v1.21+ will require roles to have an audience.", "role_name", roleName)
 	} else {
 		expected.Audiences = []string{role.Audience}

--- a/path_role.go
+++ b/path_role.go
@@ -290,8 +290,13 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 	}
 
 	var resp *logical.Response
+
+	// Warn if max_ttl is greater than system or backend mount's maximum TTL
 	if role.TokenMaxTTL > b.System().MaxLeaseTTL() {
-		resp = &logical.Response{}
+		if resp == nil {
+			resp = &logical.Response{}
+		}
+
 		resp.AddWarning("max_ttl is greater than the system or backend mount's maximum TTL value; issued tokens' max TTL value will be truncated")
 	}
 
@@ -334,9 +339,20 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
-	// optional audience field
+	// audiences will be required in kubernetes roles in a future Vault version
 	if audience, ok := data.GetOk("audience"); ok {
 		role.Audience = audience.(string)
+	}
+
+	// Vault 1.21+ will require an audience to be set on a role for security reasons.
+	// Log a warning if the role does not specify an audience.
+	if strings.TrimSpace(role.Audience) == "" {
+		if resp == nil {
+			resp = &logical.Response{}
+		}
+
+		b.Logger().Warn("This role does not have an audience. In Vault v1.21+, specifying an audience on roles will be required.", "role_name", roleName)
+		resp.AddWarning(fmt.Sprintf("Role %s does not have an audience. In Vault v1.21+, specifying an audience on roles will be required.", roleName))
 	}
 
 	if source, ok := data.GetOk("alias_name_source"); ok {


### PR DESCRIPTION
Adds a space in between sentences in the warning that audiences will be required in 1.21+.