### PR TITLE
Backport of Add space in warning message for roles requiring audiences for 1.19.x

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -353,7 +353,7 @@ func (b *kubeAuthBackend) parseAndValidateJWT(ctx context.Context, client *http.
 	// Roles will need to specify an audience in Vault v1.21+.
 	// Log a warning if the role does not specify one.
 	if strings.TrimSpace(role.Audience) == "" {
-		b.Logger().Warn("A role without an audience was used to authenticate into Vault."+
+		b.Logger().Warn("A role without an audience was used to authenticate into Vault. "+
 			"Vault v1.21+ will require roles to have an audience.", "role_name", roleName)
 	} else {
 		expected.Audiences = []string{role.Audience}


### PR DESCRIPTION
Backport of adding a space in between sentences in the warning that audiences will be required in 1.21+.