### PR TITLE
Update audience warning message for Kubernetes auth roles

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -162,7 +162,7 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrUnrecoverable
 	}
 
-	sa, err := b.parseAndValidateJWT(ctx, client, jwtStr, role, roleName, config)
+	sa, err := b.parseAndValidateJWT(ctx, client, jwtStr, role, config)
 	if err != nil {
 		if err == jose.ErrCryptoFailure || strings.Contains(err.Error(), "verifying token signature") {
 			b.Logger().Debug(`login unauthorized`, "err", err)
@@ -298,7 +298,7 @@ func (b *kubeAuthBackend) aliasLookahead(ctx context.Context, req *logical.Reque
 		return nil, logical.ErrUnrecoverable
 	}
 
-	sa, err := b.parseAndValidateJWT(ctx, client, jwtStr, role, roleName, config)
+	sa, err := b.parseAndValidateJWT(ctx, client, jwtStr, role, config)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (keySet DontVerifySignature) VerifySignature(_ context.Context, token strin
 
 // parseAndValidateJWT is used to parse, validate and lookup the JWT token.
 func (b *kubeAuthBackend) parseAndValidateJWT(ctx context.Context, client *http.Client, jwtStr string,
-	role *roleStorageEntry, roleName string, config *kubeConfig,
+	role *roleStorageEntry, config *kubeConfig,
 ) (*serviceAccount, error) {
 	expected := capjwt.Expected{
 		SigningAlgorithms: allowedSigningAlgsCap,
@@ -350,12 +350,8 @@ func (b *kubeAuthBackend) parseAndValidateJWT(ctx context.Context, client *http.
 		}
 	}
 
-	// Roles will need to specify an audience in Vault v1.21+.
-	// Log a warning if the role does not specify one.
-	if strings.TrimSpace(role.Audience) == "" {
-		b.Logger().Warn("A role without an audience was used to authenticate into Vault. "+
-			"Vault v1.21+ will require roles to have an audience.", "role_name", roleName)
-	} else {
+	// validate the audience if the role expects it
+	if role.Audience != "" {
 		expected.Audiences = []string{role.Audience}
 	}
 

--- a/path_role.go
+++ b/path_role.go
@@ -339,20 +339,18 @@ func (b *kubeAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 		return logical.ErrorResponse("can not mix %q with values", "*"), nil
 	}
 
-	// audiences will be required in kubernetes roles in a future Vault version
 	if audience, ok := data.GetOk("audience"); ok {
 		role.Audience = audience.(string)
 	}
 
-	// Vault 1.21+ will require an audience to be set on a role for security reasons.
-	// Log a warning if the role does not specify an audience.
+	// Warn if audience is not set
 	if strings.TrimSpace(role.Audience) == "" {
 		if resp == nil {
 			resp = &logical.Response{}
 		}
 
-		b.Logger().Warn("This role does not have an audience. In Vault v1.21+, specifying an audience on roles will be required.", "role_name", roleName)
-		resp.AddWarning(fmt.Sprintf("Role %s does not have an audience. In Vault v1.21+, specifying an audience on roles will be required.", roleName))
+		b.Logger().Warn("This role does not have an audience configured. While audiences are not required, consider specifying one if your use case would benefit from additional JWT claim verification.", "role_name", roleName)
+		resp.AddWarning(fmt.Sprintf("Role %s does not have an audience configured. While audiences are not required, consider specifying one if your use case would benefit from additional JWT claim verification.", roleName))
 	}
 
 	if source, ok := data.GetOk("alias_name_source"); ok {


### PR DESCRIPTION
This PR updates the warning message for roles without an audience in the Kubernetes auth plugin. Audiences are no longer going to be considered a requirement starting in Vault 1.21+, as enforcing this could break valid Kubernetes use cases (more details [here](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/300#issuecomment-3179814054)). Instead, a warning is logged to inform users when an audience is not configured, so they can decide if specifying one would be beneficial for their use case (e.g., for additional JWT claim verification).
