### PR TITLE
[CHANGELOG] Prepare for v0.24.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## v0.24.1
+### March 20, 2026
+
+* Update dependencies and changelog for v0.24.1 (#360)
+
+## v0.24.1
 ### March 19, 2026
 
 * Build with go 1.26.1


### PR DESCRIPTION
Changelog update for version [v0.24.1](https://github.com/hashicorp/vault-plugin-auth-kubernetes/releases/tag/v0.24.1).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/23351419346

