### PR TITLE
Log TokenReview reviewer failures at error, not debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Improvements
+
+* Log TokenReview API failures (HTTP 401/403, transport, TLS) at error instead of debug. HTTP 401 from `kubernetes_host` is the reviewer credential being rejected, not a deleted service account; a deleted or invalid login JWT is HTTP 200 with `status.authenticated=false`. The client still receives permission denied. [#373](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/373) [#168](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/168)
+
 ## v0.24.1
 ### March 19, 2026
 

--- a/helpers.go
+++ b/helpers.go
@@ -4,9 +4,54 @@
 package kubeauth
 
 import (
+	"errors"
+	"net"
 	"net/http"
 	"strings"
+
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 )
+
+// isTokenReviewMisconfiguration reports whether a TokenReview failure is a
+// reviewer-credential, transport, or API-server problem rather than a rejected
+// login JWT. Those failures are logged at error; expected login denials stay
+// at debug so unauthenticated clients cannot flood error logs. The HTTP
+// response to the client remains permission denied in both cases.
+func isTokenReviewMisconfiguration(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errTokenReviewUnauthorized) || errors.Is(err, errTokenReviewForbidden) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	var status kubeerrors.APIStatus
+	if errors.As(err, &status) {
+		code := status.Status().Code
+		if code == http.StatusUnauthorized || code == http.StatusForbidden || code >= 500 {
+			return true
+		}
+	}
+
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "x509:"),
+		strings.Contains(msg, "tls:"),
+		strings.Contains(msg, "no such host"),
+		strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "i/o timeout"),
+		strings.Contains(msg, "context deadline exceeded"),
+		strings.Contains(msg, "network is unreachable"):
+		return true
+	default:
+		return false
+	}
+}
 
 func setRequestHeader(req *http.Request, bearer string) {
 	bearer = strings.TrimSpace(bearer)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kubeauth
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func TestIsTokenReviewMisconfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "unauthorized sentinel", err: errTokenReviewUnauthorized, want: true},
+		{name: "forbidden sentinel", err: errTokenReviewForbidden, want: true},
+		{name: "wrapped unauthorized", err: fmt.Errorf("lookup: %w", errTokenReviewUnauthorized), want: true},
+		{name: "timeout", err: timeoutErr{}, want: true},
+		{name: "tls string", err: errors.New(`Post "https://example:443/apis/authentication.k8s.io/v1/tokenreviews": tls: failed to verify certificate: x509: certificate signed by unknown authority`), want: true},
+		{name: "dns string", err: errors.New("lookup failed: no such host"), want: true},
+		{name: "deleted-looking login jwt", err: errors.New("lookup failed: service account jwt not valid"), want: false},
+		{name: "jwt name mismatch", err: errors.New("JWT names did not match"), want: false},
+		{name: "jwt uid mismatch", err: errors.New("JWT UIDs did not match"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTokenReviewMisconfiguration(tt.err); got != tt.want {
+				t.Fatalf("isTokenReviewMisconfiguration(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/path_login.go
+++ b/path_login.go
@@ -179,7 +179,11 @@ func (b *kubeAuthBackend) pathLogin(ctx context.Context, req *logical.Request, d
 	// look up the JWT token in the kubernetes API
 	err = sa.lookup(ctx, client, jwtStr, role.Audience, b.reviewFactory(config))
 	if err != nil {
-		b.Logger().Debug(`login unauthorized`, "err", err)
+		if isTokenReviewMisconfiguration(err) {
+			b.Logger().Error("login unauthorized due to TokenReview failure", "err", err)
+		} else {
+			b.Logger().Debug("login unauthorized", "err", err)
+		}
 		return nil, logical.ErrPermissionDenied
 	}
 

--- a/token_review.go
+++ b/token_review.go
@@ -21,6 +21,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var (
+	// errTokenReviewUnauthorized is returned when kubernetes_host rejects the
+	// reviewer bearer token with HTTP 401. This is not the same as TokenReview
+	// returning authenticated=false for the login JWT: a deleted or invalid
+	// service account token is a 200 with status.authenticated=false.
+	errTokenReviewUnauthorized = errors.New("token review API unauthorized")
+
+	// errTokenReviewForbidden is returned when the reviewer lacks permission
+	// to create TokenReview objects (HTTP 403).
+	errTokenReviewForbidden = errors.New("token review API forbidden")
+)
+
 // This is the result from the token review
 type tokenReviewResult struct {
 	Name      string
@@ -83,11 +95,12 @@ func (t *tokenReviewAPI) Review(ctx context.Context, client *http.Client, jwt st
 	r, err := parseResponse(resp)
 	switch {
 	case kubeerrors.IsUnauthorized(err):
-		// If the err is unauthorized that means the token has since been deleted;
-		// this can happen if the service account is deleted, and even if it has
-		// since been recreated the token will have changed, which means our
-		// caller will need to be updated accordingly.
-		return nil, errors.New("lookup failed: service account unauthorized; this could mean it has been deleted or recreated with a new token")
+		// HTTP 401 means kubernetes_host rejected the *reviewer* bearer, not
+		// that the login JWT's service account was deleted. Deleted or invalid
+		// tokens come back as HTTP 200 with status.authenticated=false.
+		return nil, fmt.Errorf("%w: kubernetes_host rejected the reviewer credential with HTTP 401; if token_reviewer_jwt is unset the login JWT is used as the bearer and the API server must accept Kubernetes service account tokens: %v", errTokenReviewUnauthorized, err)
+	case kubeerrors.IsForbidden(err):
+		return nil, fmt.Errorf("%w: kubernetes_host rejected the reviewer credential with HTTP 403; the reviewer ServiceAccount needs the system:auth-delegator ClusterRole: %v", errTokenReviewForbidden, err)
 	case err != nil:
 		return nil, err
 	}

--- a/token_review_test.go
+++ b/token_review_test.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kubeauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTokenReviewAPI_HTTP401IsReviewerRejection(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Unauthorized","code":401}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tr := &tokenReviewAPI{config: &kubeConfig{Host: srv.URL}}
+	_, err := tr.Review(context.Background(), srv.Client(), "fake.jwt.token", nil)
+	if !errors.Is(err, errTokenReviewUnauthorized) {
+		t.Fatalf("expected errTokenReviewUnauthorized, got %v", err)
+	}
+	if !isTokenReviewMisconfiguration(err) {
+		t.Fatal("HTTP 401 from TokenReview must be classified as a misconfiguration")
+	}
+	if strings.Contains(err.Error(), "deleted") {
+		t.Fatalf("HTTP 401 must not be described as a deleted service account: %v", err)
+	}
+}
+
+func TestTokenReviewAPI_HTTP403IsReviewerRejection(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Forbidden","code":403}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tr := &tokenReviewAPI{config: &kubeConfig{Host: srv.URL}}
+	_, err := tr.Review(context.Background(), srv.Client(), "fake.jwt.token", nil)
+	if !errors.Is(err, errTokenReviewForbidden) {
+		t.Fatalf("expected errTokenReviewForbidden, got %v", err)
+	}
+	if !isTokenReviewMisconfiguration(err) {
+		t.Fatal("HTTP 403 from TokenReview must be classified as a misconfiguration")
+	}
+}
+
+func TestTokenReviewAPI_UnauthenticatedJWTIsNotMisconfiguration(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"apiVersion":"authentication.k8s.io/v1","kind":"TokenReview","status":{"authenticated":false}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tr := &tokenReviewAPI{config: &kubeConfig{Host: srv.URL}}
+	_, err := tr.Review(context.Background(), srv.Client(), "fake.jwt.token", nil)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated token")
+	}
+	if isTokenReviewMisconfiguration(err) {
+		t.Fatalf("authenticated=false is a login rejection, not a misconfiguration: %v", err)
+	}
+	if err.Error() != "lookup failed: service account jwt not valid" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
# Overview

Operators debugging Kubernetes auth logins cannot see why TokenReview failed without setting the process log level to debug. The client still gets permission denied, which is correct for an unauthenticated endpoint.

This change is for Vault operators. It does not change the login HTTP response.

# Design of Change

- HTTP 401/403 from `kubernetes_host` are reviewer-credential failures (sentinel errors), not a deleted service account. A deleted or invalid login JWT is HTTP 200 with `status.authenticated=false`.
- `pathLogin` logs reviewer / transport / TLS / API-server failures at error. JWT mismatch and `authenticated=false` stay at debug so unauthenticated clients cannot flood error logs.
- The client still receives `permission denied`.

# Related Issues/Pull Requests

- https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/373
- https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/168
- https://github.com/hashicorp/vault/issues/31139

# Contributor Checklist

- [x] Docs: TokenReview HTTP 401/403 semantics belong in the Kubernetes auth troubleshooting docs (follow-up on web-unified-docs). This PR is the logging/classification fix only.
- [x] Unit tests cover 401, 403, `authenticated=false`, and error classification. `CGO_ENABLED=0 go test -timeout=5m .` — 113 passed.
- [x] Backwards compatible: client response unchanged.

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Logging of TokenReview failures moves from debug to error for reviewer-credential and transport failures only. The login endpoint still returns permission denied and does not include the TokenReview error string in the client response.
